### PR TITLE
Hack to hide scrollbars on popups

### DIFF
--- a/packages/extension/public/popup.html
+++ b/packages/extension/public/popup.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>polkadot{.js}</title>
   </head>
-  <body style="background:#f5f6f7; box-sizing:border-box; height:580px; margin:0; padding:0 1rem; width:480px;">
+  <body style="background:#f5f6f7; box-sizing:border-box; height:580px; margin:0; overflow-x: hidden; padding:0 1rem; width:480px;">
     <div id="root"></div>
     <script src='./popup.js'></script>
   </body>

--- a/packages/extension/src/background/handlers/State.ts
+++ b/packages/extension/src/background/handlers/State.ts
@@ -91,7 +91,7 @@ export default class State {
     extension.windows.create({
       // This is not allowed on FF, only on Chrome - disable completely
       // focused: true,
-      height: 580,
+      height: 581,
       left: 150,
       top: 150,
       type: 'popup',


### PR DESCRIPTION
1. closes #80 
Not particularly proud of that one.. yet I've spent some time trying to figure out what happens.. without luck. It must be a Firefox bug.. A single pixel of the height lets a vertical scroll-bar appear, which then lets an horizontal scroll-bar appear (because in FF the scroll-bar is part of the window). So 580 -> 581 solves the whole problem. Had a look at what Metamask does and their extension is 357x600 and they open a 360x620 popup :woman_cartwheeling:.

1. Now the `overflow-x: hidden` solves another scrollbar problem when having many accounts, before
![image](https://user-images.githubusercontent.com/33178835/61243415-2f074400-a748-11e9-814e-5d9f03223a5c.png)

after
![image](https://user-images.githubusercontent.com/33178835/61243423-33cbf800-a748-11e9-901c-bdd532b09cf9.png)

Note that this is totally transparent for chrome..



