### PR TITLE
Don't fail outright on decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "yarn": "^1.10.1"
   },
   "resolutions": {
-    "@polkadot/api": "^0.92.1",
+    "@polkadot/api": "^0.93.0-beta.0",
     "@polkadot/keyring": "^1.4.1",
-    "@polkadot/types": "^0.92.1",
+    "@polkadot/types": "^0.93.0-beta.0",
     "@polkadot/util": "^1.4.1",
     "@polkadot/util-crypto": "^1.4.1",
     "babel-core": "^7.0.0-bridge.0",

--- a/packages/extension-ui/package.json
+++ b/packages/extension-ui/package.json
@@ -6,8 +6,8 @@
   "license": "Apache-2",
   "dependencies": {
     "@babel/runtime": "^7.6.0",
-    "@polkadot/react-identicon": "^0.44.1",
-    "@polkadot/react-qr": "^0.44.1",
+    "@polkadot/react-identicon": "^0.45.0-beta.5",
+    "@polkadot/react-qr": "^0.45.0-beta.5",
     "@types/react-router": "^5.0.3",
     "@types/react-router-dom": "^4.3.5",
     "react-router": "^5.0.1",

--- a/packages/extension-ui/src/Popup/Signing/Details.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Details.tsx
@@ -26,19 +26,28 @@ interface Props {
 }
 
 function renderMethod (data: string, meta?: Metadata | null): React.ReactNode {
+  let json: MethodJson;
+  let method: GenericCall;
+
+  const base = (
+    <tr>
+      <td className='label'>method data</td>
+      <td className='data'>{data}</td>
+    </tr>
+  );
+
   if (!meta) {
-    return (
-      <tr>
-        <td className='label'>method data</td>
-        <td className='data'>{data}</td>
-      </tr>
-    );
+    return base;
   }
 
-  GenericCall.injectMethods(fromMetadata(meta));
+  try {
+    GenericCall.injectMethods(fromMetadata(meta));
 
-  const method = new GenericCall(data);
-  const json = method.toJSON() as unknown as MethodJson;
+    method = new GenericCall(data);
+    json = method.toJSON() as unknown as MethodJson;
+  } catch (error) {
+    return base;
+  }
 
   return (
     <>

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -5,9 +5,9 @@
   "author": "Jaco Greeff <jacogr@gmail.com>",
   "license": "Apache-2",
   "dependencies": {
-    "@polkadot/api": "^0.92.1",
+    "@polkadot/api": "^0.93.0-beta.0",
     "@polkadot/extension-ui": "^0.11.0-beta.1",
-    "@polkadot/ui-keyring": "^0.44.1"
+    "@polkadot/ui-keyring": "^0.45.0-beta.5"
   },
   "devDependencies": {
     "@babel/runtime": "^7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1921,37 +1921,37 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@polkadot/api-derive@^0.92.1":
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.92.1.tgz#6f64adeb88b56de027f92a660d376a5eade06d40"
-  integrity sha512-sWdiXqGDTizBYhB1lws/mvYShEMvvnO12PLiauKiO+L4ps/pqCXJ2CaU3CqZajrKbx1q3JLkBGs/Fd337NKP+A==
+"@polkadot/api-derive@^0.93.0-beta.0":
+  version "0.93.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.93.0-beta.0.tgz#c608ad4312fbd561897a8cc668ab713ef97426ff"
+  integrity sha512-Pmzjxm9Hnz2/jG6unTjmz502WJhJQC1jTS4yFVX0HLJ4Y0FN+iyQP6pzwBZ20Q/lUU75sqq/xx1oj6ereovMmQ==
   dependencies:
     "@babel/runtime" "^7.6.0"
-    "@polkadot/api" "^0.92.1"
-    "@polkadot/types" "^0.92.1"
+    "@polkadot/api" "^0.93.0-beta.0"
+    "@polkadot/types" "^0.93.0-beta.0"
 
-"@polkadot/api-metadata@^0.92.1":
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-metadata/-/api-metadata-0.92.1.tgz#8a5ce741df96cf01e3637acbd963bf021355b905"
-  integrity sha512-7kF1Jrk2Lnyxp3GuNfOzHPqzq8olzK8Xgz+TCiDLfPAemnI/WunkaZNS7sD43GQ7ifjdrXPHTg5iI+NBQqZeag==
+"@polkadot/api-metadata@^0.93.0-beta.0":
+  version "0.93.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-metadata/-/api-metadata-0.93.0-beta.0.tgz#a46c627cf2c75724f1be91bd79c2a0a292af8d7a"
+  integrity sha512-QoqZ0sLtz849VyVqDnrQzdF5FJuBKsQ7xLeHLJE/CQqYMTUSjZxzXHipXa036I2447kLbk++3L25TOn5tZf1IQ==
   dependencies:
     "@babel/runtime" "^7.6.0"
-    "@polkadot/types" "^0.92.1"
+    "@polkadot/types" "^0.93.0-beta.0"
     "@polkadot/util" "^1.4.1"
     "@polkadot/util-crypto" "^1.4.1"
 
-"@polkadot/api@^0.92.1":
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.92.1.tgz#a1ffd869bf25a5452383f6dd41733221d86554d2"
-  integrity sha512-4bjCCAUXc7GH6V7+1MaSi3NaUhUV9dJVMYXF0QmzUrAux6Rhd7SCzOUXIADY9ONbah/L+uu2EquSrvWaPQXuwg==
+"@polkadot/api@^0.93.0-beta.0":
+  version "0.93.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.93.0-beta.0.tgz#e41e85c68a18620da25a2b82d971c575c72a3b2a"
+  integrity sha512-da2nCpmuNr0KCGrGyzj5zKrJOWdBNiokHMfN2h6S0j35u6uHfCBGJznkRgvoLbzDdnhKouadCzvO+JCLIQsjrQ==
   dependencies:
     "@babel/runtime" "^7.6.0"
-    "@polkadot/api-derive" "^0.92.1"
-    "@polkadot/api-metadata" "^0.92.1"
+    "@polkadot/api-derive" "^0.93.0-beta.0"
+    "@polkadot/api-metadata" "^0.93.0-beta.0"
     "@polkadot/keyring" "^1.4.1"
-    "@polkadot/rpc-core" "^0.92.1"
-    "@polkadot/rpc-provider" "^0.92.1"
-    "@polkadot/types" "^0.92.1"
+    "@polkadot/rpc-core" "^0.93.0-beta.0"
+    "@polkadot/rpc-provider" "^0.93.0-beta.0"
+    "@polkadot/types" "^0.93.0-beta.0"
     "@polkadot/util-crypto" "^1.4.1"
 
 "@polkadot/dev-react@^0.31.0-beta.8":
@@ -2035,10 +2035,10 @@
     typescript "^3.6.3"
     vuepress "^1.0.4"
 
-"@polkadot/jsonrpc@^0.92.1":
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.92.1.tgz#29eb4121c163afc8e285593b1e0587529edbc15f"
-  integrity sha512-XMBlb26APmpiyMOcWbsLwAfpIO9mlY+n1Ysc4dLEivK4mOt6S9CL1UkvuTRRs1IvPHVsQre3iAOYJfxv1r+JrQ==
+"@polkadot/jsonrpc@^0.93.0-beta.0":
+  version "0.93.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.93.0-beta.0.tgz#417b593379be1f94756a23bbfc60865a4edf0075"
+  integrity sha512-5nWb3UBMPuc4XLnHCz2Z5DP/SbcTS1fEwGgf0PcjYlpaGlV9joCm/GFx+RlHbOmsChjNQwuzlFdAd6uV4iYWWg==
   dependencies:
     "@babel/runtime" "^7.6.0"
 
@@ -2051,14 +2051,14 @@
     "@polkadot/util" "^1.4.1"
     "@polkadot/util-crypto" "^1.4.1"
 
-"@polkadot/react-identicon@^0.44.1":
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/react-identicon/-/react-identicon-0.44.1.tgz#0abf772aaf91c385b24a3aabd12beecef59cca71"
-  integrity sha512-qz5Jtv6JCALIEWj3dr0AroGD2CNwkHcw8Cm2TKlLmzMoWDY/LA0JRQhBqoLQOVlK8lnFmO4x5sRGWjiGSsL8Bg==
+"@polkadot/react-identicon@^0.45.0-beta.5":
+  version "0.45.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/react-identicon/-/react-identicon-0.45.0-beta.5.tgz#264d16f839a98bbf253c408f4007d35b1eba6efc"
+  integrity sha512-poJhZz0utVw/vgDbRh/rPYdXDjo4OlyrTlvACY4t+tSh8QWTz6OG0ODaHeOR5pH5VVYYQnID9wRNVbR+zfXrbQ==
   dependencies:
     "@babel/runtime" "^7.6.0"
-    "@polkadot/ui-settings" "^0.44.1"
-    "@polkadot/ui-shared" "^0.44.1"
+    "@polkadot/ui-settings" "^0.45.0-beta.5"
+    "@polkadot/ui-shared" "^0.45.0-beta.5"
     "@types/color" "^3.0.0"
     "@types/react-copy-to-clipboard" "^4.2.6"
     color "^3.1.2"
@@ -2066,35 +2066,35 @@
     react-copy-to-clipboard "^5.0.1"
     styled-components "^4.3.1"
 
-"@polkadot/react-qr@^0.44.1":
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/react-qr/-/react-qr-0.44.1.tgz#7cca0324b0d068b545db15f2e068937141b8d7f1"
-  integrity sha512-05ExUes/N+pnoBuVhcerKgYYhTzv2JqoylNozIYAL+4nL90rY6zno34yFniKKbNbHPgtWLg4fzOZH3IlBugq1g==
+"@polkadot/react-qr@^0.45.0-beta.5":
+  version "0.45.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/react-qr/-/react-qr-0.45.0-beta.5.tgz#ac6ea8f4077ee6e014136eab66d5ea7d47b3f3b9"
+  integrity sha512-7pfhqCjFfNy7sy3suC7q50gU35a1OIvq9cHyJj6VBIgV2CNvyGCZWgbv+fa5YlXfC0+HVconqtz8NsVoqb+8Qw==
   dependencies:
     "@babel/runtime" "^7.6.0"
     "@types/react-qr-reader" "^2.1.1"
     qrcode-generator "^1.4.3"
     react-qr-reader "^2.2.1"
 
-"@polkadot/rpc-core@^0.92.1":
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.92.1.tgz#f5ed3cacfdadc08ca7363c2d8f8d4246c37b88cd"
-  integrity sha512-AI75J3nN+VCG3eePNXInqnIxNp3lZIQQf4im65KdAupoZlb0bKDr8rIaw7Dxpy2TzQB52SxekSUDIaHQ2Wrqsw==
+"@polkadot/rpc-core@^0.93.0-beta.0":
+  version "0.93.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.93.0-beta.0.tgz#f2da2af40a9f80b408beb315c592b8938067bc10"
+  integrity sha512-vCE7iYCMGIwy8tAY5qbcYKXJg+B1Jro7mrP/0Li662GpkhoZf7TP8Drzx1jQ9wJBeHyRNhWDq8CQkTqJmArBsA==
   dependencies:
     "@babel/runtime" "^7.6.0"
-    "@polkadot/jsonrpc" "^0.92.1"
-    "@polkadot/rpc-provider" "^0.92.1"
-    "@polkadot/types" "^0.92.1"
+    "@polkadot/jsonrpc" "^0.93.0-beta.0"
+    "@polkadot/rpc-provider" "^0.93.0-beta.0"
+    "@polkadot/types" "^0.93.0-beta.0"
     "@polkadot/util" "^1.4.1"
     rxjs "^6.5.3"
 
-"@polkadot/rpc-provider@^0.92.1":
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.92.1.tgz#1896f86bc6c4f2b2da2c415426f0454a73c40bed"
-  integrity sha512-Vnb5JAn5E4PDR+p+sftIbbuh031K3lyE+rkTZMtVhmLr8m+/XXo18xuMvTd7YCIXOmYOm6dDMdTE/AK0pL6Sqw==
+"@polkadot/rpc-provider@^0.93.0-beta.0":
+  version "0.93.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.93.0-beta.0.tgz#2c75eaf82f349f0ac78dd3684db585a80100a2ac"
+  integrity sha512-ZW4qGctfj/beNTCeVOVvuY7NF1rgUfFHvuDtzmD/11yehL2GsEDXEgzUV3IdW0pvIjX2po+TNcqFIJvSDKCNIw==
   dependencies:
     "@babel/runtime" "^7.6.0"
-    "@polkadot/api-metadata" "^0.92.1"
+    "@polkadot/api-metadata" "^0.93.0-beta.0"
     "@polkadot/util" "^1.4.1"
     "@polkadot/util-crypto" "^1.4.1"
     "@types/nock" "^10.0.3"
@@ -2109,10 +2109,10 @@
   dependencies:
     "@types/chrome" "^0.0.88"
 
-"@polkadot/types@^0.92.1":
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.92.1.tgz#18de5809fc91c22c72db097d70aabe76ec9215bc"
-  integrity sha512-LLutXpwxX9PkHK2wQBWR5lh2nCceiLMwFBYG97uM/SYEpMfwRt0kjKIc/8ISwiewYtH03hXA8AmFa4NB2PyuSA==
+"@polkadot/types@^0.93.0-beta.0":
+  version "0.93.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.93.0-beta.0.tgz#e778020ccd5ca211901a7893f4b6dd34a966d618"
+  integrity sha512-tj4FdIq5HwTN3KfBHTz4U0WjxdD5TrYyxH2iulcubFV5sAgBuYyZy5fGdGmY/K87oUP/viBplMl94Yn67+aBZg==
   dependencies:
     "@babel/runtime" "^7.6.0"
     "@polkadot/util" "^1.4.1"
@@ -2120,10 +2120,10 @@
     "@types/memoizee" "^0.4.3"
     memoizee "^0.4.14"
 
-"@polkadot/ui-keyring@^0.44.1":
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.44.1.tgz#7df7baae75bf7da1cbd848fb0594fb95b28702a0"
-  integrity sha512-YsM82junqV4TuxJ3417c5U/ZxfvZmr8Qv5koiKnxU/dj3Vmxfp2NvoqdhzfsxRjMiPQToK++n0PrEGazv9Llww==
+"@polkadot/ui-keyring@^0.45.0-beta.5":
+  version "0.45.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.45.0-beta.5.tgz#7855f6270175725fee2ce412b3eaf3ab1240302b"
+  integrity sha512-L1kbkcpjMhSyfL3yzf7dAPnCmTU8VZuKbmMJopG7Pl2ZZBMSd5AJtwk5inVPVSddBNsS+j58BHr6JAno94Kl2w==
   dependencies:
     "@babel/runtime" "^7.6.0"
     "@types/mkdirp" "^0.5.2"
@@ -2133,19 +2133,19 @@
     store "^2.0.12"
     styled-components "^4.3.1"
 
-"@polkadot/ui-settings@^0.44.1":
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.44.1.tgz#e6c11146428af6a99fbdb60bbbf8ddf7a70b529c"
-  integrity sha512-ibjXKJZFKhTTLNH5TPDVVQMXf6jUh69uBDntk73sk+tJ394UaqMOYyfbpxb3xsnVOBUt9SvJ1y8RtAggpISlpw==
+"@polkadot/ui-settings@^0.45.0-beta.5":
+  version "0.45.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.45.0-beta.5.tgz#30f17062d5dd1fb3e826ac7c193c0e6673c3fefc"
+  integrity sha512-7ZiuxWYgpG6lyFQlXSiL6qDA6kKLYCAzL4b+hWkVs+iGIB2D/0M7wWiEp4uCtSYpfRTCvlG6n5oNsrjjJqOOUA==
   dependencies:
     "@babel/runtime" "^7.6.0"
     "@types/store" "^2.0.2"
     store "^2.0.12"
 
-"@polkadot/ui-shared@^0.44.1":
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-shared/-/ui-shared-0.44.1.tgz#a4e6ea78528790e134ee86c71ab45b3ca0d679cb"
-  integrity sha512-v0ygtHHaQWCWZbKGqHSUnKzqIb652Nz4MRglX1AzBkJjax7SpPKm90ewSpn+vOiRVuuBx2DBRtBootDrnxCunQ==
+"@polkadot/ui-shared@^0.45.0-beta.5":
+  version "0.45.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-shared/-/ui-shared-0.45.0-beta.5.tgz#3d5d0b76d3000e361099426df056172bf4f93ea0"
+  integrity sha512-stIUHVPhF0XOcmJqsZxwYvEwUN5wlpAEOxQ7VcrFdpommVIN9fSl4UuPQ6MD9/3xY6blCADZFAwG6tmXLuzkxg==
   dependencies:
     "@babel/runtime" "^7.6.0"
     "@types/color" "^3.0.0"


### PR DESCRIPTION
When the metadata cannot decode the method, don't end up with a blank screen - addresses what was found in #148 

Testing this now - it will solve the immediate problem, but we also need to add the missing types (which is the actual cause here), on a per-chain basis. So a follow-up PR for this will also be made.

EDIT: Tested with setKeys, it now works exactly as expected. This really should have been picked-up earlier. Horrible.