### PR TITLE
Implement signRaw

### DIFF
--- a/packages/extension-ui/src/Popup/Signing/Bytes.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Bytes.tsx
@@ -1,0 +1,59 @@
+// Copyright 2019 @polkadot/extension-ui authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import styled from 'styled-components';
+import React from 'react';
+
+interface Props {
+  className?: string;
+  bytes: string;
+  url: string;
+}
+
+function Bytes ({ bytes, className, url }: Props): React.ReactElement<Props> {
+  return (
+    <table className={className}>
+      <tbody>
+        <tr>
+          <td className='label'>from</td>
+          <td className='data'>{url}</td>
+        </tr>
+        <tr>
+          <td className='label'>bytes</td>
+          <td className='data'>{bytes}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+export default styled(Bytes)`
+  border: 0;
+  display: block;
+  font-size: 0.75rem;
+  margin-top: 0.75rem;
+
+  td.data {
+    max-width: 0;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    width: 100%;
+
+    pre {
+      font-family: inherit;
+      font-size: 0.75rem;
+      margin: 0;
+    }
+  }
+
+  td.label {
+    opacity: 0.5;
+    padding: 0 0.5rem;
+    text-align: right;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+`;

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic.tsx
@@ -92,7 +92,7 @@ function mortalityAsString (era: ExtrinsicEra, hexBlockNumber: string): string {
   return `mortal, valid from #${formatNumber(mortal.birth(blockNumber))} to #${formatNumber(mortal.death(blockNumber))}`;
 }
 
-function Details ({ className, isDecoded, payload: { era, nonce, tip }, request: { blockNumber, genesisHash, method, specVersion: hexSpec }, url }: Props): React.ReactElement<Props> {
+function Extrinsic ({ className, isDecoded, payload: { era, nonce, tip }, request: { blockNumber, genesisHash, method, specVersion: hexSpec }, url }: Props): React.ReactElement<Props> {
   const chain = useRef(findChain(genesisHash)).current;
   const specVersion = useRef(bnToBn(hexSpec)).current;
   const [decoded, setDecoded] = useState<Decoded>({ json: null, method: null });
@@ -136,7 +136,7 @@ function Details ({ className, isDecoded, payload: { era, nonce, tip }, request:
   );
 }
 
-export default styled(Details)`
+export default styled(Extrinsic)`
   border: 0;
   display: block;
   font-size: 0.75rem;

--- a/packages/extension/src/background/RequestBytesSign.ts
+++ b/packages/extension/src/background/RequestBytesSign.ts
@@ -1,0 +1,23 @@
+// Copyright 2019 @polkadot/extension authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { KeyringPair } from '@polkadot/keyring/types';
+import { RequestSign } from './types';
+import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
+import { u8aToHex, hexToU8a } from '@polkadot/util';
+import { TypeRegistry } from '@polkadot/types';
+
+export default class RequestBytesSign implements RequestSign {
+  inner: SignerPayloadJSON | SignerPayloadRaw;
+
+  constructor (inner: SignerPayloadRaw) {
+    this.inner = inner;
+  }
+
+  sign (_registry: TypeRegistry, pair: KeyringPair): { signature: string } {
+    const inner = this.inner as SignerPayloadRaw;
+    const signedBytes = pair.sign(hexToU8a(inner.data));
+    return { signature: u8aToHex(signedBytes) };
+  }
+}

--- a/packages/extension/src/background/RequestExtrinsicSign.ts
+++ b/packages/extension/src/background/RequestExtrinsicSign.ts
@@ -1,0 +1,22 @@
+// Copyright 2019 @polkadot/extension authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { createType, TypeRegistry } from '@polkadot/types';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { RequestSign } from './types';
+import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
+
+export default class RequestExtrinsicSign implements RequestSign {
+  inner: SignerPayloadJSON | SignerPayloadRaw;
+
+  constructor (inner: SignerPayloadJSON) {
+    this.inner = inner;
+  }
+
+  sign (registry: TypeRegistry, pair: KeyringPair): { signature: string } {
+    const inner = this.inner as SignerPayloadJSON;
+    const extrinsic = createType(registry, 'ExtrinsicPayload', this.inner, { version: inner.version });
+    return extrinsic.sign(pair);
+  }
+}

--- a/packages/extension/src/background/handlers/Extension.ts
+++ b/packages/extension/src/background/handlers/Extension.ts
@@ -8,7 +8,7 @@ import { AccountJson, AuthorizeRequest, MessageTypes, RequestAccountCreateExtern
 import extension from 'extensionizer';
 import keyring from '@polkadot/ui-keyring';
 import accountsObservable from '@polkadot/ui-keyring/observable/accounts';
-import { TypeRegistry, createType } from '@polkadot/types';
+import { TypeRegistry } from '@polkadot/types';
 import { assert, isHex } from '@polkadot/util';
 import { keyExtractSuri, mnemonicGenerate, mnemonicValidate } from '@polkadot/util-crypto';
 
@@ -153,7 +153,7 @@ export default class Extension {
     assert(queued, 'Unable to find request');
 
     const { request, resolve, reject } = queued;
-    const pair = keyring.getPair(request.address);
+    const pair = keyring.getPair(request.inner.address);
 
     if (!pair) {
       reject(new Error('Unable to find pair'));
@@ -162,10 +162,7 @@ export default class Extension {
     }
 
     pair.decodePkcs8(password);
-
-    const payload = createType(registry, 'ExtrinsicPayload', request, { version: request.version });
-    const result = payload.sign(pair);
-
+    const result = request.sign(registry, pair);
     pair.lock();
 
     resolve({

--- a/packages/extension/src/background/handlers/State.ts
+++ b/packages/extension/src/background/handlers/State.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AccountJson, AuthorizeRequest, RequestAuthorizeTab, RequestExtrinsicSign, ResponseExtrinsicSign, SigningRequest } from '../types';
+import { AccountJson, AuthorizeRequest, RequestAuthorizeTab, RequestSign, ResponseSigning, SigningRequest } from '../types';
 
 import extension from 'extensionizer';
 import { BehaviorSubject } from 'rxjs';
@@ -28,8 +28,8 @@ type AuthUrls = Record<string, {
 interface SignRequest {
   account: AccountJson;
   id: string;
-  request: RequestExtrinsicSign;
-  resolve: (result: ResponseExtrinsicSign) => void;
+  request: RequestSign;
+  resolve: (result: ResponseSigning) => void;
   reject: (error: Error) => void;
   url: string;
 }
@@ -125,8 +125,8 @@ export default class State {
     };
   }
 
-  private signComplete = (id: string, fn: Function): (result: ResponseExtrinsicSign | Error) => void => {
-    return (result: ResponseExtrinsicSign | Error): void => {
+  private signComplete = (id: string, fn: Function): (result: ResponseSigning | Error) => void => {
+    return (result: ResponseSigning | Error): void => {
       delete this._signRequests[id];
       this.updateIconSign(true);
 
@@ -211,7 +211,7 @@ export default class State {
     return this._signRequests[id];
   }
 
-  public signQueue (url: string, request: RequestExtrinsicSign, account: AccountJson): Promise<ResponseExtrinsicSign> {
+  public sign (url: string, request: RequestSign, account: AccountJson): Promise<ResponseSigning> {
     const id = getId();
 
     return new Promise((resolve, reject): void => {

--- a/packages/extension/src/background/types.ts
+++ b/packages/extension/src/background/types.ts
@@ -3,8 +3,10 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { InjectedAccount } from '@polkadot/extension-inject/types';
-import { SignerPayloadJSON } from '@polkadot/types/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
+import { TypeRegistry } from '@polkadot/types';
 
 type KeysWithDefinedValues<T> = {
   [K in keyof T]: T[K] extends undefined ? never : K
@@ -36,7 +38,7 @@ export interface AuthorizeRequest {
 export interface SigningRequest {
   account: AccountJson;
   id: string;
-  request: RequestExtrinsicSign;
+  request: RequestSign;
   url: string;
 }
 
@@ -63,7 +65,8 @@ export interface RequestSignatures {
   'pub(accounts.list)': [RequestAccountList, InjectedAccount[]];
   'pub(accounts.subscribe)': [RequestAccountSubscribe, boolean, InjectedAccount[]];
   'pub(authorize.tab)': [RequestAuthorizeTab, null];
-  'pub(extrinsic.sign)': [RequestExtrinsicSign, ResponseExtrinsicSign];
+  'pub(bytes.sign)': [SignerPayloadRaw, ResponseSigning];
+  'pub(extrinsic.sign)': [SignerPayloadJSON, ResponseSigning];
 }
 
 export type MessageTypes = keyof RequestSignatures;
@@ -130,8 +133,6 @@ export type RequestAccountList = null;
 
 export type RequestAccountSubscribe = null;
 
-export type RequestExtrinsicSign = SignerPayloadJSON;
-
 export interface RequestSigningApprovePassword {
   id: string;
   password: string;
@@ -184,7 +185,7 @@ export type TransportResponseMessage<TMessageType extends MessageTypes> =
       ? TransportResponseMessageSub<TMessageType>
       : never;
 
-export interface ResponseExtrinsicSign {
+export interface ResponseSigning {
   id: string;
   signature: string;
 }
@@ -211,3 +212,8 @@ export type SubscriptionMessageTypes = NoUndefinedValues<{
 
 export type MessageTypesWithSubscriptions = keyof SubscriptionMessageTypes;
 export type MessageTypesWithNoSubscriptions = Exclude<MessageTypes, keyof SubscriptionMessageTypes>
+
+export interface RequestSign {
+  inner: SignerPayloadJSON | SignerPayloadRaw;
+  sign(registry: TypeRegistry, pair: KeyringPair): { signature: string };
+}

--- a/packages/extension/src/page/Signer.ts
+++ b/packages/extension/src/page/Signer.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Signer as SignerInterface, SignerResult } from '@polkadot/api/types';
-import { SignerPayloadJSON } from '@polkadot/types/types';
+import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import { SendRequest } from './types';
 
 let sendRequest: SendRequest;
@@ -30,16 +30,15 @@ export default class Signer implements SignerInterface {
     };
   }
 
-  // TODO To implement signing of arbitrary payloads via signRaw
-  // public async signRaw (payload: SignerPayloadRaw): Promise<SignerResult> {
-  //   const id = ++nextId;
-  //   const result = await sendRequest('bytes.sign', payload);
+  public async signRaw (payload: SignerPayloadRaw): Promise<SignerResult> {
+    const id = ++nextId;
+    const result = await sendRequest('pub(bytes.sign)', payload);
 
-  //   return {
-  //     ...result,
-  //     id
-  //   };
-  // }
+    return {
+      ...result,
+      id
+    };
+  }
 
   // NOTE We don't listen to updates at all, if we do we can interpret the
   // resuklt as provided by the API here


### PR DESCRIPTION
Fixes #115 

With the following interface:

```ts
export interface RequestSign {
  inner: SignerPayloadJSON | SignerPayloadRaw;
  sign(pair: KeyringPair): { signature: string };
}
```

`extension` package abstracts the signing procedure using the `sign` method and because `extension-ui` needs to be aware if it is dealing with an extrinsic or a bunch of bytes, `inner` returns the inner payload content of its implementations.