### PR TITLE
Provider Injection

### DIFF
--- a/packages/extension-dapp/src/index.ts
+++ b/packages/extension-dapp/src/index.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Injected, InjectedAccount, InjectedAccountWithMeta, InjectedExtension, InjectedExtensionInfo, InjectedWindow, Unsubcall } from '@polkadot/extension-inject/types';
+import { Injected, InjectedAccount, InjectedAccountWithMeta, InjectedExtension, InjectedExtensionInfo, InjectedProviderWithMeta, InjectedWindow, Unsubcall } from '@polkadot/extension-inject/types';
 
 // just a helper (otherwise we cast all-over, so shorter and more readable)
 const win = window as Window & InjectedWindow;
@@ -175,4 +175,28 @@ export async function web3FromAddress (address: string): Promise<InjectedExtensi
   }
 
   return web3FromSource(found.meta.source);
+}
+
+// retrieve all the providers accross all extensions
+export async function web3Providers (): Promise<InjectedProviderWithMeta[]> {
+  if (!web3EnablePromise) {
+    return throwError('web3Providers');
+  }
+
+  const injected = await web3EnablePromise;
+  const providers: InjectedProviderWithMeta[] = injected
+    .map(({ provider, name: source }): InjectedProviderWithMeta | null =>
+      provider
+        ? { provider, meta: { source } }
+        : null
+    )
+    .filter((x): x is InjectedProviderWithMeta =>
+      x !== null
+    );
+
+  const sources = providers.map(({ meta: { source } }): string => source);
+
+  console.log(`web3Providers: Found ${providers.length} provider${providers.length !== 1 ? 's' : ''} from extension${sources.length !== 1 ? 's' : ''} ${sources.join(', ')}`);
+
+  return providers;
 }

--- a/packages/extension-inject/src/types.ts
+++ b/packages/extension-inject/src/types.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Signer as InjectedSigner } from '@polkadot/api/types';
+import { ProviderInterface } from '@polkadot/rpc-provider/types';
 
 // eslint-disable-next-line no-undef
 type This = typeof globalThis;
@@ -34,9 +35,19 @@ export interface InjectedExtensionInfo {
   version: string;
 }
 
+export type InjectedProvider = ProviderInterface;
+
+export interface InjectedProviderWithMeta {
+  provider: InjectedProvider;
+  meta: {
+    source: string;
+  };
+}
+
 export interface Injected {
   accounts: InjectedAccounts;
   signer: InjectedSigner;
+  provider: InjectedProvider;
 }
 
 export interface InjectedWindowProvider {

--- a/packages/extension/src/background/types.ts
+++ b/packages/extension/src/background/types.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { InjectedAccount } from '@polkadot/extension-inject/types';
-import { JsonRpcRequest, JsonRpcResponse } from '@polkadot/rpc-provider/types';
+import { JsonRpcResponse } from '@polkadot/rpc-provider/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
@@ -68,8 +68,9 @@ export interface RequestSignatures {
   'pub(authorize.tab)': [RequestAuthorizeTab, null];
   'pub(bytes.sign)': [SignerPayloadRaw, ResponseSigning];
   'pub(extrinsic.sign)': [SignerPayloadJSON, ResponseSigning];
-  'pub(rpc.send)': [JsonRpcRequest, JsonRpcResponse];
-  'pub(rpc.subscribe)': [JsonRpcRequest, JsonRpcResponse];
+  'pub(rpc.provider)': [RequestRpcProvider, null];
+  'pub(rpc.send)': [RequestRpcSend, JsonRpcResponse];
+  'pub(rpc.subscribe)': [RequestRpcSubscribe, JsonRpcResponse];
 }
 
 export type MessageTypes = keyof RequestSignatures;
@@ -135,6 +136,25 @@ export interface RequestAccountExport {
 export type RequestAccountList = null;
 
 export type RequestAccountSubscribe = null;
+
+// JSON-serializable data to instantiate a provider.
+export interface ProviderJSON {
+  // Payload to pass into Provider constructor
+  payload: string;
+  type: 'WsProvider';
+}
+
+export type RequestRpcProvider = ProviderJSON;
+
+export interface RequestRpcSend {
+  method: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: any[];
+}
+
+export interface RequestRpcSubscribe extends RequestRpcSend {
+  type: string;
+}
 
 export interface RequestSigningApprovePassword {
   id: string;

--- a/packages/extension/src/background/types.ts
+++ b/packages/extension/src/background/types.ts
@@ -240,5 +240,5 @@ export type MessageTypesWithNoSubscriptions = Exclude<MessageTypes, keyof Subscr
 export interface RequestSign {
   readonly inner: SignerPayloadJSON | SignerPayloadRaw;
 
-  sign(registry: TypeRegistry, pair: KeyringPair): { signature: string };
+  sign (registry: TypeRegistry, pair: KeyringPair): { signature: string };
 }

--- a/packages/extension/src/background/types.ts
+++ b/packages/extension/src/background/types.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { InjectedAccount } from '@polkadot/extension-inject/types';
+import { JsonRpcRequest, JsonRpcResponse } from '@polkadot/rpc-provider/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
@@ -67,6 +68,8 @@ export interface RequestSignatures {
   'pub(authorize.tab)': [RequestAuthorizeTab, null];
   'pub(bytes.sign)': [SignerPayloadRaw, ResponseSigning];
   'pub(extrinsic.sign)': [SignerPayloadJSON, ResponseSigning];
+  'pub(rpc.send)': [JsonRpcRequest, JsonRpcResponse];
+  'pub(rpc.subscribe)': [JsonRpcRequest, JsonRpcResponse];
 }
 
 export type MessageTypes = keyof RequestSignatures;
@@ -216,5 +219,5 @@ export type MessageTypesWithNoSubscriptions = Exclude<MessageTypes, keyof Subscr
 export interface RequestSign {
   readonly inner: SignerPayloadJSON | SignerPayloadRaw;
 
-  sign (registry: TypeRegistry, pair: KeyringPair): { signature: string };
+  sign(registry: TypeRegistry, pair: KeyringPair): { signature: string };
 }

--- a/packages/extension/src/background/types.ts
+++ b/packages/extension/src/background/types.ts
@@ -141,7 +141,8 @@ export type RequestAccountSubscribe = null;
 export interface ProviderJSON {
   // Payload to pass into Provider constructor
   payload: string;
-  type: 'WsProvider';
+  // Provider type: 'WsProvider' etc.
+  type: string;
 }
 
 export type RequestRpcProvider = ProviderJSON;

--- a/packages/extension/src/page/Injected.ts
+++ b/packages/extension/src/page/Injected.ts
@@ -7,14 +7,18 @@ import { SendRequest } from './types';
 
 import Accounts from './Accounts';
 import Signer from './Signer';
+import PostMessageProvider from './PostMessageProvider';
 
 export default class implements Injected {
   public readonly accounts: Accounts;
+
+  public readonly provider: PostMessageProvider;
 
   public readonly signer: Signer;
 
   constructor (sendRequest: SendRequest) {
     this.accounts = new Accounts(sendRequest);
     this.signer = new Signer(sendRequest);
+    this.provider = new PostMessageProvider(sendRequest);
   }
 }

--- a/packages/extension/src/page/PostMessageProvider.ts
+++ b/packages/extension/src/page/PostMessageProvider.ts
@@ -1,0 +1,145 @@
+// Copyright 2019 @polkadot/extension authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { InjectedProvider } from '@polkadot/extension-inject/types';
+import Coder from '@polkadot/rpc-provider/coder';
+import { ProviderInterfaceEmitCb, ProviderInterfaceEmitted } from '@polkadot/rpc-provider/types';
+import { AnyFunction } from '@polkadot/types/types';
+import { isUndefined, logger } from '@polkadot/util';
+import EventEmitter from 'eventemitter3';
+
+import { SendRequest } from './types';
+
+const l = logger('PostMessageProvider');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CallbackHandler = (error?: null | Error, value?: any) => void;
+
+// Same as https://github.com/polkadot-js/api/blob/57ca9a9c3204339e1e1f693fcacc33039868dc27/packages/rpc-provider/src/ws/Provider.ts#L17
+interface SubscriptionHandler {
+  callback: CallbackHandler;
+  type: string;
+}
+
+/**
+ * @name PostMessageProvider
+ *
+ * @description Extension provider to be used by dapps
+ */
+export default class PostMessageProvider implements InjectedProvider {
+  readonly #coder: Coder;
+
+  readonly #eventemitter: EventEmitter;
+
+  readonly #sendRequest: SendRequest;
+
+  // Subscription IDs are (historically) not guaranteed to be globally unique;
+  // only unique for a given subscription method; which is why we identify
+  // the subscriptions based on subscription id + type
+  readonly #subscriptions: Record<string, AnyFunction> = {}; // {[(type,subscriptionId)]: callback}
+
+  /**
+   * @param {function}  sendRequest  The function to be called to send requests to the node
+   * @param {function}  subscriptionNotificationHandler  Channel for receiving subscription messages
+   */
+  public constructor (sendRequest: SendRequest) {
+    this.#coder = new Coder();
+    this.#eventemitter = new EventEmitter();
+    this.#sendRequest = sendRequest;
+
+    // Give subscribers time to subscribe
+    setTimeout((): void => {
+      this.#eventemitter.emit('connected');
+    });
+  }
+
+  /**
+   * @description Returns a clone of the object
+   */
+  public clone (): PostMessageProvider {
+    return new PostMessageProvider(this.#sendRequest);
+  }
+
+  /**
+   * @description Manually disconnect from the connection, clearing autoconnect logic
+   */
+  public disconnect (): void {
+    console.error('PostMessageProvider.disconnect() is not implemented.');
+  }
+
+  /**
+   * @summary `true` when this provider supports subscriptions
+   */
+  public get hasSubscriptions (): boolean {
+    return true;
+  }
+
+  /**
+   * @summary Whether the node is connected or not.
+   * @return {boolean} true if connected
+   */
+  public isConnected (): boolean {
+    return true; // connects on first RPC request
+  }
+
+  /**
+   * @summary Listens on events after having subscribed using the [[subscribe]] function.
+   * @param  {ProviderInterfaceEmitted} type Event
+   * @param  {ProviderInterfaceEmitCb}  sub  Callback
+   * @return unsubscribe function
+   */
+  public on (type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): () => void {
+    this.#eventemitter.on(type, sub);
+
+    return (): void => {
+      this.#eventemitter.removeListener(type, sub);
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public send (method: string, params: any[], subscription?: SubscriptionHandler): Promise<any> {
+    const json = this.#coder.encodeObject(method, params);
+
+    if (subscription) {
+      const { callback, type } = subscription;
+      return this.#sendRequest('pub(rpc.subscribe)', json).then(({ id }): number => {
+        this.#subscriptions[`${type}::${id}`] = callback;
+
+        return id;
+      });
+    } else {
+      return this.#sendRequest('pub(rpc.send)', json);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async subscribe (type: string, method: string, params: any[], callback: AnyFunction): Promise<number> {
+    const id = await this.send(method, params, { type, callback });
+
+    return id as number;
+  }
+
+  /**
+   * @summary Allows unsubscribing to subscriptions made with [[subscribe]].
+   */
+  public async unsubscribe (type: string, method: string, id: number): Promise<boolean> {
+    const subscription = `${type}::${id}`;
+
+    // FIXME This now could happen with re-subscriptions. The issue is that with a re-sub
+    // the assigned id now does not match what the API user originally received. It has
+    // a slight complication in solving - since we cannot rely on the send id, but rather
+    // need to find the actual subscription id to map it
+    if (isUndefined(this.#subscriptions[subscription])) {
+      l.debug((): string => `Unable to find active subscription=${subscription}`);
+
+      return false;
+    }
+
+    delete this.#subscriptions[subscription];
+
+    const result = await this.send(method, [id]);
+
+    return result as boolean;
+  }
+}

--- a/packages/extension/src/page/PostMessageProvider.ts
+++ b/packages/extension/src/page/PostMessageProvider.ts
@@ -61,6 +61,7 @@ export default class PostMessageProvider implements InjectedProvider {
    * @description Manually disconnect from the connection, clearing autoconnect logic
    */
   public disconnect (): void {
+    // FIXME This should see if the extension's state's provider can disconnect
     console.error('PostMessageProvider.disconnect() is not implemented.');
   }
 
@@ -68,6 +69,7 @@ export default class PostMessageProvider implements InjectedProvider {
    * @summary `true` when this provider supports subscriptions
    */
   public get hasSubscriptions (): boolean {
+    // FIXME This should see if the extension's state's provider has subscriptions
     return true;
   }
 
@@ -76,7 +78,8 @@ export default class PostMessageProvider implements InjectedProvider {
    * @return {boolean} true if connected
    */
   public isConnected (): boolean {
-    return true; // connects on first RPC request
+    // FIXME This should see if the extension's state's provider is connected
+    return true;
   }
 
   /**


### PR DESCRIPTION
reviving #88

- Added 3 messages: `pub(rpc.send)`, `pub(rpc.subscribe)` (self-explanatory) and `pub(rpc.provider)`, this one is to change the provider the extension is holding

cc @sjeohp