### PR TITLE
Extend popup width

### DIFF
--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -200,7 +200,6 @@ function Address ({ actions, address, children, className, genesisHash, isHidden
 }
 
 const FullAddress = styled.div(({ theme }: ThemeProps) => `
-  width: 270px;
   overflow: hidden;
   text-overflow: ellipsis;
   color: ${theme.labelColor};

--- a/packages/extension/public/index.html
+++ b/packages/extension/public/index.html
@@ -5,7 +5,7 @@
     <title>polkadot{.js}</title>
   </head>
   <body style="height: 600px; margin:0; overflow-x:hidden; text-align:center">
-    <div id="root" style="box-sizing:border-box; margin:0 auto; padding:0; text-align:left; width:480px; height: calc(100% - 2px); max-width: 100%;"></div>
+    <div id="root" style="box-sizing:border-box; margin:0 auto; padding:0; text-align:left; width:570px; height: calc(100% - 2px); max-width: 100%;"></div>
     <script src='./extension.js'></script>
   </body>
 </html>


### PR DESCRIPTION
Part of https://github.com/polkadot-js/extension/issues/414 - allows the addresses to be fuly visible at all time while allow more space for actual names & derivation paths.