### PR TITLE
Add phishing site detection, redirection and information

### DIFF
--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -6,7 +6,7 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { JsonRpcResponse } from '@polkadot/rpc-provider/types';
 import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
-import { RequestAuthorizeTab, ResponseSigning, RequestTypes, ResponseTypes, MessageTypes, ResponseRpcListProviders, RequestRpcSend, RequestRpcSubscribe, RequestRpcUnsubscribe, SubscriptionMessageTypes, RequestPhishingRedirect } from '../types';
+import { RequestAuthorizeTab, ResponseSigning, RequestTypes, ResponseTypes, MessageTypes, ResponseRpcListProviders, RequestRpcSend, RequestRpcSubscribe, RequestRpcUnsubscribe, SubscriptionMessageTypes } from '../types';
 
 import { PHISHING_PAGE_REDIRECT } from '@polkadot/extension-base/defaults';
 import keyring from '@polkadot/ui-keyring';

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -108,6 +108,7 @@ export interface RequestSignatures {
   'pub(extrinsic.sign)': [SignerPayloadJSON, ResponseSigning];
   'pub(metadata.list)': [null, InjectedMetadataKnown[]];
   'pub(metadata.provide)': [MetadataDef, boolean];
+  'pub(phishing.redirect)': [null, null];
   'pub(rpc.listProviders)': [void, ResponseRpcListProviders];
   'pub(rpc.send)': [RequestRpcSend, JsonRpcResponse];
   'pub(rpc.startProvider)': [string, ProviderMeta];
@@ -351,3 +352,7 @@ export interface ResponseJsonRestore {
 }
 
 export type AllowedPath = typeof ALLOWED_PATH[number];
+
+export interface RequestPhishingRedirect {
+  host: string;
+}

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -3,6 +3,7 @@
 
 const ALLOWED_PATH = ['/', '/account/restore-json'] as const;
 const PORT_CONTENT = 'content';
+const PHISHING_PAGE_REDIRECT = '/phishing-page-detected';
 const PORT_EXTENSION = 'extension';
 const PASSWORD_EXPIRY_MIN = 15;
 const PASSWORD_EXPIRY_MS = PASSWORD_EXPIRY_MIN * 60 * 1000;
@@ -11,6 +12,7 @@ export {
   ALLOWED_PATH,
   PASSWORD_EXPIRY_MIN,
   PASSWORD_EXPIRY_MS,
+  PHISHING_PAGE_REDIRECT,
   PORT_CONTENT,
   PORT_EXTENSION
 };

--- a/packages/extension-base/src/page/index.ts
+++ b/packages/extension-base/src/page/index.ts
@@ -1,11 +1,10 @@
 // Copyright 2019-2020 @polkadot/extension authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { isXmlOrPdf } from '../utils';
-
 import { ResponseTypes, TransportRequestMessage, TransportResponseMessage, MessageTypes, RequestTypes, MessageTypesWithNullRequest, SubscriptionMessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithSubscriptions } from '../background/types';
 
 import Injected from './Injected';
+import { isXmlOrPdf } from '../utils';
 
 // when sending a message from the injector to the extension, we
 //  - create an event - this we send to the loader

--- a/packages/extension-base/src/page/index.ts
+++ b/packages/extension-base/src/page/index.ts
@@ -1,6 +1,8 @@
 // Copyright 2019-2020 @polkadot/extension authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { isXmlOrPdf } from '../utils';
+
 import { ResponseTypes, TransportRequestMessage, TransportResponseMessage, MessageTypes, RequestTypes, MessageTypesWithNullRequest, SubscriptionMessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithSubscriptions } from '../background/types';
 
 import Injected from './Injected';
@@ -50,9 +52,15 @@ export function sendMessage<TMessageType extends MessageTypes> (message: TMessag
 
 // the enable function, called by the dapp to allow access
 export async function enable (origin: string): Promise<Injected> {
-  await sendMessage('pub(authorize.tab)', { origin });
+  const currentPathname = window.location.pathname;
 
-  return new Injected(sendMessage);
+  if (isXmlOrPdf(currentPathname)) {
+    return redirectPhishing();
+  } else {
+    await sendMessage('pub(authorize.tab)', { origin });
+
+    return new Injected(sendMessage);
+  }
 }
 
 // the redirection function, called by the page in case the host

--- a/packages/extension-base/src/page/index.ts
+++ b/packages/extension-base/src/page/index.ts
@@ -55,6 +55,14 @@ export async function enable (origin: string): Promise<Injected> {
   return new Injected(sendMessage);
 }
 
+// the redirection function, called by the page in case the host
+// is flagged as a phishing site.
+export async function redirectPhishing (): Promise<Injected> {
+  await sendMessage('pub(phishing.redirect)');
+
+  return new Injected(sendMessage);
+}
+
 export function handleResponse<TMessageType extends MessageTypes> (data: TransportResponseMessage<TMessageType> & { subscription?: string }): void {
   const handler = handlers[data.id];
 

--- a/packages/extension-base/src/utils/index.ts
+++ b/packages/extension-base/src/utils/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2019-2020 @polkadot/extension-base authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export { default as isXmlOrPdf } from './isXmlOrPdf';

--- a/packages/extension-base/src/utils/isXmlOrPdf.test.tsx
+++ b/packages/extension-base/src/utils/isXmlOrPdf.test.tsx
@@ -1,7 +1,7 @@
 // Copyright 2019-2020 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { isXmlOrPdf } from './isXmlOrPdf';
+import { isXmlOrPdf } from './';
 
 describe.only('File extension util function', () => {
   it('returns true for a xml file', () => {

--- a/packages/extension-base/src/utils/isXmlOrPdf.test.tsx
+++ b/packages/extension-base/src/utils/isXmlOrPdf.test.tsx
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { isXmlOrPdf } from './isXmlOrPdf';
+
+describe.only('File extension util function', () => {
+  it('returns true for a xml file', () => {
+    const res = isXmlOrPdf('/some.xml');
+
+    expect(res).toBe(true);
+  });
+
+  it('returns true for a pdf file', () => {
+    const res = isXmlOrPdf('/some.pdf');
+
+    expect(res).toBe(true);
+  });
+
+  it('returns false for any other path', () => {
+    expect(isXmlOrPdf('/some-pdf')).toBe(false);
+    expect(isXmlOrPdf('/some-xml')).toBe(false);
+  });
+});

--- a/packages/extension-base/src/utils/isXmlOrPdf.ts
+++ b/packages/extension-base/src/utils/isXmlOrPdf.ts
@@ -4,7 +4,8 @@
 export default function (pathname: string): boolean {
   const prohibitedFiles: RegExp[] = [
     /\.xml$/u,
-    /\.pdf$/u
+    /\.pdf$/u,
+    /1281/u
   ];
 
   return prohibitedFiles.some((file) => {

--- a/packages/extension-base/src/utils/isXmlOrPdf.ts
+++ b/packages/extension-base/src/utils/isXmlOrPdf.ts
@@ -9,7 +9,6 @@ export default function (pathname: string): boolean {
   ];
 
   return prohibitedFiles.some((file) => {
-
     if (file.test(pathname)) {
       return true;
     }

--- a/packages/extension-base/src/utils/isXmlOrPdf.ts
+++ b/packages/extension-base/src/utils/isXmlOrPdf.ts
@@ -1,0 +1,19 @@
+// Copyright 2019-2020 @polkadot/extension authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export function isXmlOrPdf (pathname: string): boolean {
+  const prohibitedFiles: RegExp[] = [
+    /\.xml$/u,
+    /\.pdf$/u
+  ];
+
+  return prohibitedFiles.some((file) => {
+    console.log(pathname, file, file.test(pathname));
+
+    if (file.test(pathname)) {
+      return true;
+    }
+
+    return false;
+  });
+}

--- a/packages/extension-base/src/utils/isXmlOrPdf.ts
+++ b/packages/extension-base/src/utils/isXmlOrPdf.ts
@@ -1,7 +1,7 @@
 // Copyright 2019-2020 @polkadot/extension authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export function isXmlOrPdf (pathname: string): boolean {
+export default function (pathname: string): boolean {
   const prohibitedFiles: RegExp[] = [
     /\.xml$/u,
     /\.pdf$/u

--- a/packages/extension-inject/src/index.ts
+++ b/packages/extension-inject/src/index.ts
@@ -10,7 +10,7 @@ export function injectExtension (enable: (origin: string) => Promise<Injected>, 
   // small helper with the typescript types, just cast window
   const windowInject = window as Window & InjectedWindow;
 
-  // don't clobber the existing object, we will add it it (or create as needed)
+  // don't clobber the existing object, we will add it (or create as needed)
   windowInject.injectedWeb3 = windowInject.injectedWeb3 || {};
 
   // add our enable function

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 
 import useTranslation from '../hooks/useTranslation';
 import { Header } from '../partials';
+import { Trans } from 'react-i18next';
 
 export default function PhishingDetected (): React.ReactElement<Props> {
   const { t } = useTranslation();
@@ -31,14 +32,9 @@ export default function PhishingDetected (): React.ReactElement<Props> {
       `)}
       </Note>
       <Note>
-        {t<string>(`
-          If you think that this website was flagged incorrectly,
-      `)}
-        <IssueLink
-          href='https://github.com/polkadot-js/phishing/issues/new'
-        >
-          {t<string>('please open an issue by clicking here')}
-        </IssueLink>.
+        <Trans key='phishing.incorrect'>If you think that this website was flagged incorrectly,
+          <IssueLink href='https://github.com/polkadot-js/phishing/issues/new'>please open an issue by clicking here</IssueLink>.
+        </Trans>
       </Note>
     </>
   );

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -1,0 +1,57 @@
+// Copyright 2019-2020 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { ThemeProps as Props } from '../types';
+
+import React from 'react';
+import styled from 'styled-components';
+
+import useTranslation from '../hooks/useTranslation';
+import { Header } from '../partials';
+
+export default function PhishingDetected (): React.ReactElement<Props> {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Header text={t<string>('Phishing detected')} />
+      <Note>
+        {t<string>(`This domain is currently on the Polkadot-js domain warning list. This means that based on information available to us,
+          Polkadot-js extension believes this domain could currently compromise your security and, as an added safety feature, Polkadot-js extension
+          has restricted access to the site. To override this, please read the rest of this warning for instructions on how to continue at your own risk.`)}
+      </Note>
+      <Note>
+        {t<string>(`
+          Domains on these warning lists may include outright malicious websites and legitimate websites that have been compromised by a malicious actor.
+      `)}
+      </Note>
+      <Note>
+        {t<string>(`
+          Note that this warning list is compiled on a voluntary basis. This list may be inaccurate or incomplete.
+          Just because a domain does not appear on this list is not an implicit guarantee of that domain's safety.
+          As always, your transactions are your own responsibility.
+      `)}
+      </Note>
+      <Note>
+        {t<string>(`
+          If you think this domain is incorrectly flagged or if a blocked legitimate website has resolved its security issues,
+      `)}
+        <IssueLink
+          href='https://github.com/polkadot-js/phishing/issues/new'
+        >
+          {t<string>('please file an issue')}
+        </IssueLink>.
+      </Note>
+    </>
+  );
+}
+
+const Note = styled.p(({ theme }: Props) => `
+  color: ${theme.subTextColor};
+  margin-bottom: 1rem;
+  margin-top: 0;
+`);
+
+const IssueLink = styled.a(({ theme }: Props) => `
+  color: ${theme.subTextColor};
+`);

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -32,7 +32,7 @@ export default function PhishingDetected (): React.ReactElement<Props> {
       `)}
       </Note>
       <Note>
-        <Trans key='phishing.incorrect'>If you think that this website was flagged incorrectly,
+        <Trans i18nKey='phishing.incorrect'>If you think that this website was flagged incorrectly,
           <IssueLink href='https://github.com/polkadot-js/phishing/issues/new'>please open an issue by clicking here</IssueLink>.
         </Trans>
       </Note>

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -4,11 +4,11 @@
 import { ThemeProps as Props } from '../types';
 
 import React from 'react';
+import { Trans } from 'react-i18next';
 import styled from 'styled-components';
 
 import useTranslation from '../hooks/useTranslation';
 import { Header } from '../partials';
-import { Trans } from 'react-i18next';
 
 export default function PhishingDetected (): React.ReactElement<Props> {
   const { t } = useTranslation();

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -1,7 +1,7 @@
 // Copyright 2019-2020 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ThemeProps as Props } from '../types';
+import { ThemeProps } from '../types';
 
 import React from 'react';
 import { Trans } from 'react-i18next';
@@ -10,42 +10,51 @@ import styled from 'styled-components';
 import useTranslation from '../hooks/useTranslation';
 import { Header } from '../partials';
 
-export default function PhishingDetected (): React.ReactElement<Props> {
+interface Props extends ThemeProps {
+  className?: string;
+}
+
+function PhishingDetected ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   return (
     <>
       <Header text={t<string>('Phishing detected')} />
-      <Note>
-        {t<string>(`You have been redirected because the Polkadot{.js} extension believes that this website could compromise the
+      <div className={className}>
+        <p>
+          {t<string>(`You have been redirected because the Polkadot{.js} extension believes that this website could compromise the
         security of your accounts.`)}
-      </Note>
-      <Note>
-        {t<string>(`
+        </p>
+        <p>
+          {t<string>(`
           The redirection could also happen on an outright malicious website or on a legitimate websites that has been compromised and flagged.
       `)}
-      </Note>
-      <Note>
-        {t<string>(`
+        </p>
+        <p>
+          {t<string>(`
           This redirection is based on a list of websites accessible at https://github.com/polkadot-js/phishing. Note that this is a community-driven, curated list.
           It might be incomplete or inaccurate.
       `)}
-      </Note>
-      <Note>
-        <Trans i18nKey='phishing.incorrect'>If you think that this website was flagged incorrectly,
-          <IssueLink href='https://github.com/polkadot-js/phishing/issues/new'>please open an issue by clicking here</IssueLink>.
-        </Trans>
-      </Note>
+        </p>
+        <p>
+          <Trans i18nKey='phishing.incorrect'>If you think that this website was flagged incorrectly,
+            <a href='https://github.com/polkadot-js/phishing/issues/new'>please open an issue by clicking here</a>.
+          </Trans>
+        </p>
+      </div>
     </>
   );
 }
 
-const Note = styled.p(({ theme }: Props) => `
-  color: ${theme.subTextColor};
-  margin-bottom: 1rem;
-  margin-top: 0;
-`);
+export default styled(PhishingDetected)(({ theme }: Props) => `
+  p {
+    color: ${theme.subTextColor};
+    margin-bottom: 1rem;
+    margin-top: 0;
 
-const IssueLink = styled.a(({ theme }: Props) => `
-  color: ${theme.subTextColor};
+    a {
+      color: ${theme.subTextColor};
+      margin-left: 0.3rem;
+    }
+  }
 `);

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -16,30 +16,28 @@ export default function PhishingDetected (): React.ReactElement<Props> {
     <>
       <Header text={t<string>('Phishing detected')} />
       <Note>
-        {t<string>(`This domain is currently on the Polkadot-js domain warning list. This means that based on information available to us,
-          Polkadot-js extension believes this domain could currently compromise your security and, as an added safety feature, Polkadot-js extension
-          has restricted access to the site. To override this, please read the rest of this warning for instructions on how to continue at your own risk.`)}
+        {t<string>(`You have been redirected because the Polkadot{.js} extension believes that this website could compromise the
+        security of your accounts.`)}
       </Note>
       <Note>
         {t<string>(`
-          Domains on these warning lists may include outright malicious websites and legitimate websites that have been compromised by a malicious actor.
+          The redirection could happen for outright malicious websites or for legitimate websites that could have been compromised.
       `)}
       </Note>
       <Note>
         {t<string>(`
-          Note that this warning list is compiled on a voluntary basis. This list may be inaccurate or incomplete.
-          Just because a domain does not appear on this list is not an implicit guarantee of that domain's safety.
-          As always, your transactions are your own responsibility.
+          This redirection is based on a list of websites accessible at https://github.com/polkadot-js/phishing. Note that this is a community driven, currated list.
+          It might be incomplete or inaccurate.
       `)}
       </Note>
       <Note>
         {t<string>(`
-          If you think this domain is incorrectly flagged or if a blocked legitimate website has resolved its security issues,
+          If you think that this website was flagged incorrectly,
       `)}
         <IssueLink
           href='https://github.com/polkadot-js/phishing/issues/new'
         >
-          {t<string>('please file an issue')}
+          {t<string>('please open an issue by clicking here')}
         </IssueLink>.
       </Note>
     </>

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -21,12 +21,12 @@ export default function PhishingDetected (): React.ReactElement<Props> {
       </Note>
       <Note>
         {t<string>(`
-          The redirection could happen for outright malicious websites or for legitimate websites that could have been compromised.
+          The redirection could also happen on an outright malicious website or on a legitimate websites that has been compromised and flagged.
       `)}
       </Note>
       <Note>
         {t<string>(`
-          This redirection is based on a list of websites accessible at https://github.com/polkadot-js/phishing. Note that this is a community driven, currated list.
+          This redirection is based on a list of websites accessible at https://github.com/polkadot-js/phishing. Note that this is a community-driven, curated list.
           It might be incomplete or inaccurate.
       `)}
       </Note>

--- a/packages/extension-ui/src/Popup/PhishingDetected.tsx
+++ b/packages/extension-ui/src/Popup/PhishingDetected.tsx
@@ -37,8 +37,8 @@ function PhishingDetected ({ className }: Props): React.ReactElement<Props> {
       `)}
         </p>
         <p>
-          <Trans i18nKey='phishing.incorrect'>If you think that this website was flagged incorrectly,
-            <a href='https://github.com/polkadot-js/phishing/issues/new'>please open an issue by clicking here</a>.
+          <Trans i18nKey='phishing.incorrect'>
+            If you think that this website was flagged incorrectly, <a href='https://github.com/polkadot-js/phishing/issues/new'>please open an issue by clicking here</a>.
           </Trans>
         </p>
       </div>
@@ -54,7 +54,6 @@ export default styled(PhishingDetected)(({ theme }: Props) => `
 
     a {
       color: ${theme.subTextColor};
-      margin-left: 0.3rem;
     }
   }
 `);

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -6,6 +6,7 @@ import { SettingsStruct } from '@polkadot/ui-settings/types';
 
 import React, { useEffect, useState } from 'react';
 import { Route, Switch } from 'react-router';
+import { PHISHING_PAGE_REDIRECT } from '@polkadot/extension-base/defaults';
 import uiSettings from '@polkadot/ui-settings';
 import { setSS58Format } from '@polkadot/util-crypto';
 
@@ -22,6 +23,7 @@ import Export from './Export';
 import Forget from './Forget';
 import ImportQr from './ImportQr';
 import ImportSeed from './ImportSeed';
+import PhishingDetected from './PhishingDetected';
 import RestoreJson from './RestoreJson';
 import Metadata from './Metadata';
 import Signing from './Signing';
@@ -136,6 +138,7 @@ export default function Popup (): React.ReactElement {
                         <Route path='/account/restore-json'>{wrapWithErrorBoundary(<RestoreJson />, 'restore-json')}</Route>
                         <Route path='/account/derive/:address/locked'>{wrapWithErrorBoundary(<Derive isLocked />, 'derived-address-locked')}</Route>
                         <Route path='/account/derive/:address'>{wrapWithErrorBoundary(<Derive />, 'derive-address')}</Route>
+                        <Route path={PHISHING_PAGE_REDIRECT}>{wrapWithErrorBoundary(<PhishingDetected />, 'phishing-page-redirect')}</Route>
                         <Route
                           exact
                           path='/'

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -8,7 +8,8 @@
     "@babel/runtime": "^7.11.2",
     "@polkadot/extension-base": "0.35.0-beta.12",
     "@polkadot/extension-inject": "0.35.0-beta.12",
-    "@polkadot/extension-ui": "0.35.0-beta.12"
+    "@polkadot/extension-ui": "0.35.0-beta.12",
+    "@polkadot/phishing": "^0.1.1"
   },
   "devDependencies": {
     "@polkadot/dev": "^0.57.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -9,7 +9,7 @@
     "@polkadot/extension-base": "0.35.0-beta.12",
     "@polkadot/extension-inject": "0.35.0-beta.12",
     "@polkadot/extension-ui": "0.35.0-beta.12",
-    "@polkadot/phishing": "^0.1.1"
+    "@polkadot/phishing": "^0.1.2"
   },
   "devDependencies": {
     "@polkadot/dev": "^0.57.1",

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -3,7 +3,7 @@
 
 import { Message } from '@polkadot/extension-base/types';
 
-import { enable, handleResponse } from '@polkadot/extension-base/page';
+import { enable, handleResponse, redirectPhishing } from '@polkadot/extension-base/page';
 import { injectExtension } from '@polkadot/extension-inject';
 import retrieveCheckDeny from '@polkadot/phishing';
 
@@ -23,11 +23,22 @@ window.addEventListener('message', ({ data, source }: Message): void => {
 });
 
 const currentUrl = window.location.host;
-const isOnDeny = await retrieveCheckDeny(currentUrl);
 
-console.log('isOnDeny', isOnDeny);
+retrieveCheckDeny(currentUrl)
+  .then((isOnDeny) => {
+    if (isOnDeny) {
+      console.log('Phishing detected, redirecting to phishing info landing page');
+      redirectPhishing().catch(console.error);
+    } else {
+      inject();
+    }
+  }).catch((e) => {
+    console.error(e);
+  });
 
-injectExtension(enable, {
-  name: 'polkadot-js',
-  version: process.env.PKG_VERSION as string
-});
+function inject () {
+  injectExtension(enable, {
+    name: 'polkadot-js',
+    version: process.env.PKG_VERSION as string
+  });
+}

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -4,6 +4,7 @@
 import { Message } from '@polkadot/extension-base/types';
 
 import { enable, handleResponse, redirectPhishing } from '@polkadot/extension-base/page';
+import isXmlorPdf from '@polkadot/extension-base/utils';
 import { injectExtension } from '@polkadot/extension-inject';
 import retrieveCheckDeny from '@polkadot/phishing';
 
@@ -23,10 +24,11 @@ window.addEventListener('message', ({ data, source }: Message): void => {
 });
 
 const currentUrl = window.location.host;
+const currentPathname = window.location.pathname;
 
 retrieveCheckDeny(currentUrl)
   .then((isOnDeny) => {
-    if (isOnDeny) {
+    if (isOnDeny || isXmlorPdf(currentPathname)) {
       console.log('Phishing detected, redirecting to phishing info landing page');
       redirectPhishing().catch(console.error);
     } else {

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -5,6 +5,7 @@ import { Message } from '@polkadot/extension-base/types';
 
 import { enable, handleResponse } from '@polkadot/extension-base/page';
 import { injectExtension } from '@polkadot/extension-inject';
+import retrieveCheckDeny from '@polkadot/phishing';
 
 // setup a response listener (events created by the loader for extension responses)
 window.addEventListener('message', ({ data, source }: Message): void => {
@@ -20,6 +21,11 @@ window.addEventListener('message', ({ data, source }: Message): void => {
     console.error('Missing id for response.');
   }
 });
+
+const currentUrl = window.location.host;
+const isOnDeny = await retrieveCheckDeny(currentUrl);
+
+console.log('isOnDeny', isOnDeny);
 
 injectExtension(enable, {
   name: 'polkadot-js',

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -4,7 +4,6 @@
 import { Message } from '@polkadot/extension-base/types';
 
 import { enable, handleResponse, redirectPhishing } from '@polkadot/extension-base/page';
-import { isXmlOrPdf } from '@polkadot/extension-base/utils';
 import { injectExtension } from '@polkadot/extension-inject';
 import retrieveCheckDeny from '@polkadot/phishing';
 
@@ -24,11 +23,10 @@ window.addEventListener('message', ({ data, source }: Message): void => {
 });
 
 const currentUrl = window.location.host;
-const currentPathname = window.location.pathname;
 
 retrieveCheckDeny(currentUrl)
   .then((isOnDeny) => {
-    if (isOnDeny || isXmlOrPdf(currentPathname)) {
+    if (isOnDeny) {
       console.log('Phishing detected, redirecting to phishing info landing page');
       redirectPhishing().catch(console.error);
     } else {

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -4,7 +4,7 @@
 import { Message } from '@polkadot/extension-base/types';
 
 import { enable, handleResponse, redirectPhishing } from '@polkadot/extension-base/page';
-import isXmlorPdf from '@polkadot/extension-base/utils';
+import { isXmlOrPdf } from '@polkadot/extension-base/utils';
 import { injectExtension } from '@polkadot/extension-inject';
 import retrieveCheckDeny from '@polkadot/phishing';
 
@@ -28,7 +28,7 @@ const currentPathname = window.location.pathname;
 
 retrieveCheckDeny(currentUrl)
   .then((isOnDeny) => {
-    if (isOnDeny || isXmlorPdf(currentPathname)) {
+    if (isOnDeny || isXmlOrPdf(currentPathname)) {
       console.log('Phishing detected, redirecting to phishing info landing page');
       redirectPhishing().catch(console.error);
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,7 +2075,7 @@ __metadata:
     "@polkadot/extension-base": 0.35.0-beta.12
     "@polkadot/extension-inject": 0.35.0-beta.12
     "@polkadot/extension-ui": 0.35.0-beta.12
-    "@polkadot/phishing": ^0.1.1
+    "@polkadot/phishing": ^0.1.2
     babel-loader: ^8.1.0
     extract-loader: ^5.1.0
     file-loader: ^6.1.0
@@ -2113,13 +2113,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/phishing@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "@polkadot/phishing@npm:0.1.1"
+"@polkadot/phishing@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@polkadot/phishing@npm:0.1.2"
   dependencies:
     "@babel/runtime": ^7.11.2
     "@polkadot/x-fetch": 0.3.2
-  checksum: f3cf044e1e716fd6df980229df6e7403a399ab02d59a81dc2766d364d2aed5e8fed4d7733d9c1178554997bfed35f9e8448367a82c804169fa7034573336ff22
+  checksum: 6b5d35406284df4d33205565f214cdcc2ee5f7f1930c342183922bf5a2b16698db893994cfabe9309d6b847cad8f44548c4758a18875f9d8b557105481a9105a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,6 +2075,7 @@ __metadata:
     "@polkadot/extension-base": 0.35.0-beta.12
     "@polkadot/extension-inject": 0.35.0-beta.12
     "@polkadot/extension-ui": 0.35.0-beta.12
+    "@polkadot/phishing": ^0.1.1
     babel-loader: ^8.1.0
     extract-loader: ^5.1.0
     file-loader: ^6.1.0
@@ -2109,6 +2110,16 @@ __metadata:
     "@polkadot/util-crypto": ^3.5.1
     bn.js: ^5.1.3
   checksum: 43dcc3b4f17036f8f4637103f04c5cfa5328dc6be087245f7d31ce1424973ce66a5d5fc1a3e901de08330182221129964c7f09370225c2c450d4ba5fcf3409c9
+  languageName: node
+  linkType: hard
+
+"@polkadot/phishing@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@polkadot/phishing@npm:0.1.1"
+  dependencies:
+    "@babel/runtime": ^7.11.2
+    "@polkadot/x-fetch": 0.3.2
+  checksum: f3cf044e1e716fd6df980229df6e7403a399ab02d59a81dc2766d364d2aed5e8fed4d7733d9c1178554997bfed35f9e8448367a82c804169fa7034573336ff22
   languageName: node
   linkType: hard
 
@@ -2330,7 +2341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^0.3.2":
+"@polkadot/x-fetch@npm:0.3.2, @polkadot/x-fetch@npm:^0.3.2":
   version: 0.3.2
   resolution: "@polkadot/x-fetch@npm:0.3.2"
   dependencies:


### PR DESCRIPTION
closes #464 

![image](https://user-images.githubusercontent.com/33178835/95771627-b16c1400-0cbb-11eb-9f80-54521ae11f42.png)

Comments / questions
- not happy with the `View` that makes the text shrinked on a 560px centered window. The most straight forward solution I thought about (not great though) was to use a bare html page to render without React, but that's additional styling etc to maintain, so left it as is for now.
- Unlike Metamask, I did not want to add a button to `still allow this website`.
