### PR TITLE
Password caching refactoring

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -318,7 +318,9 @@ export default class Extension {
     }
 
     // if the keyring pair is locked, the password is needed
-    assert(!pair.isLocked || !!password, 'Password needed to unlock the account');
+    if (pair.isLocked && !password) {
+      reject(new Error('Password needed to unlock the account'));
+    }
 
     if (pair.isLocked) {
       pair.decodePkcs8(password);

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -3,7 +3,7 @@
 
 import { MetadataDef } from '@polkadot/extension-inject/types';
 import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
-import { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MetadataRequest, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountPasswordCacheUpdate, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestAuthorizeReject, RequestDeriveCreate, ResponseDeriveValidate, RequestMetadataApprove, RequestMetadataReject, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestSeedCreate, RequestTypes, ResponseAccountExport, RequestAccountForget, ResponseSeedCreate, RequestSeedValidate, RequestDeriveValidate, ResponseSeedValidate, ResponseType, SigningRequest, RequestJsonRestore, ResponseJsonRestore } from '../types';
+import { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MetadataRequest, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountPasswordCacheRefresh, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestAuthorizeReject, RequestDeriveCreate, ResponseDeriveValidate, RequestMetadataApprove, RequestMetadataReject, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestSeedCreate, RequestTypes, ResponseAccountExport, RequestAccountForget, ResponseSeedCreate, RequestSeedValidate, RequestDeriveValidate, ResponseSeedValidate, ResponseType, SigningRequest, RequestJsonRestore, ResponseJsonRestore } from '../types';
 
 import { ALLOWED_PATH, PASSWORD_EXPIRY_MS } from '@polkadot/extension-base/defaults';
 import chrome from '@polkadot/extension-inject/chrome';
@@ -94,7 +94,7 @@ export default class Extension {
     return true;
   }
 
-  private accountPasswordCacheUpdate ({ address }: RequestAccountPasswordCacheUpdate): void {
+  private refreshAccountPasswordCache ({ address }: RequestAccountPasswordCacheRefresh): void {
     const pair = keyring.getPair(address);
 
     assert(pair, 'Unable to find pair');
@@ -304,7 +304,7 @@ export default class Extension {
     const queued = this.#state.getSignRequest(id);
     const address = queued.account.address;
 
-    this.accountPasswordCacheUpdate({ address });
+    this.refreshAccountPasswordCache({ address });
 
     assert(queued, 'Unable to find request');
 
@@ -476,8 +476,8 @@ export default class Extension {
       case 'pri(accounts.forget)':
         return this.accountsForget(request as RequestAccountForget);
 
-      case 'pri(accounts.passwordCacheUpdate)':
-        return this.accountPasswordCacheUpdate(request as RequestAccountPasswordCacheUpdate);
+      case 'pri(accounts.refreshPasswordCache)':
+        return this.refreshAccountPasswordCache(request as RequestAccountPasswordCacheRefresh);
 
       case 'pri(accounts.show)':
         return this.accountsShow(request as RequestAccountShow);

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -97,7 +97,7 @@ export interface RequestSignatures {
   'pri(signing.approve.password)': [RequestSigningApprovePassword, boolean];
   'pri(signing.approve.signature)': [RequestSigningApproveSignature, boolean];
   'pri(signing.cancel)': [RequestSigningCancel, boolean];
-  'pri(signing.isLocked)': [RequestSigningIsLocked, boolean];
+  'pri(signing.isLocked)': [RequestSigningIsLocked, ResponseSigningIsLocked];
   'pri(signing.requests)': [RequestSigningSubscribe, boolean, SigningRequest[]];
   'pri(window.open)': [AllowedPath, boolean];
   // public/external requests, i.e. from a page
@@ -259,6 +259,11 @@ export interface RequestSigningCancel {
 
 export interface RequestSigningIsLocked {
   id: string;
+}
+
+export interface ResponseSigningIsLocked {
+  isLocked: boolean;
+  remainingTime: number;
 }
 
 export type RequestSigningSubscribe = null;

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -74,7 +74,7 @@ export interface RequestSignatures {
   'pri(accounts.edit)': [RequestAccountEdit, boolean];
   'pri(accounts.export)': [RequestAccountExport, ResponseAccountExport];
   'pri(accounts.forget)': [RequestAccountForget, boolean];
-  'pri(accounts.passwordCacheUpdate)': [RequestAccountPasswordCacheUpdate, void];
+  'pri(accounts.refreshPasswordCache)': [RequestAccountPasswordCacheRefresh, void];
   'pri(accounts.show)': [RequestAccountShow, boolean];
   'pri(accounts.tie)': [RequestAccountTie, boolean];
   'pri(accounts.subscribe)': [RequestAccountSubscribe, boolean, AccountJson[]];
@@ -224,7 +224,7 @@ export interface RequestAccountExport {
   password: string;
 }
 
-export interface RequestAccountPasswordCacheUpdate {
+export interface RequestAccountPasswordCacheRefresh {
   address: string;
 }
 

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -74,7 +74,6 @@ export interface RequestSignatures {
   'pri(accounts.edit)': [RequestAccountEdit, boolean];
   'pri(accounts.export)': [RequestAccountExport, ResponseAccountExport];
   'pri(accounts.forget)': [RequestAccountForget, boolean];
-  'pri(accounts.refreshPasswordCache)': [RequestAccountPasswordCacheRefresh, void];
   'pri(accounts.show)': [RequestAccountShow, boolean];
   'pri(accounts.tie)': [RequestAccountTie, boolean];
   'pri(accounts.subscribe)': [RequestAccountSubscribe, boolean, AccountJson[]];

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -74,7 +74,7 @@ export interface RequestSignatures {
   'pri(accounts.edit)': [RequestAccountEdit, boolean];
   'pri(accounts.export)': [RequestAccountExport, ResponseAccountExport];
   'pri(accounts.forget)': [RequestAccountForget, boolean];
-  'pri(accounts.passwordCached)': [RequestAccountPasswordCached, boolean];
+  'pri(accounts.passwordCacheUpdate)': [RequestAccountPasswordCacheUpdate, void];
   'pri(accounts.show)': [RequestAccountShow, boolean];
   'pri(accounts.tie)': [RequestAccountTie, boolean];
   'pri(accounts.subscribe)': [RequestAccountSubscribe, boolean, AccountJson[]];
@@ -224,7 +224,7 @@ export interface RequestAccountExport {
   password: string;
 }
 
-export interface RequestAccountPasswordCached {
+export interface RequestAccountPasswordCacheUpdate {
   address: string;
 }
 

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -224,10 +224,6 @@ export interface RequestAccountExport {
   password: string;
 }
 
-export interface RequestAccountPasswordCacheRefresh {
-  address: string;
-}
-
 export type RequestAccountList = null;
 
 export type RequestAccountSubscribe = null;

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -74,6 +74,7 @@ export interface RequestSignatures {
   'pri(accounts.edit)': [RequestAccountEdit, boolean];
   'pri(accounts.export)': [RequestAccountExport, ResponseAccountExport];
   'pri(accounts.forget)': [RequestAccountForget, boolean];
+  'pri(accounts.passwordCached)': [RequestAccountPasswordCached, boolean];
   'pri(accounts.show)': [RequestAccountShow, boolean];
   'pri(accounts.tie)': [RequestAccountTie, boolean];
   'pri(accounts.subscribe)': [RequestAccountSubscribe, boolean, AccountJson[]];
@@ -223,6 +224,10 @@ export interface RequestAccountExport {
   password: string;
 }
 
+export interface RequestAccountPasswordCached {
+  address: string;
+}
+
 export type RequestAccountList = null;
 
 export type RequestAccountSubscribe = null;
@@ -244,8 +249,8 @@ export interface RequestRpcUnsubscribe {
 
 export interface RequestSigningApprovePassword {
   id: string;
-  isSavedPass: boolean;
-  password: string;
+  password?: string;
+  savePass: boolean;
 }
 
 export interface RequestSigningApproveSignature {

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -5,7 +5,7 @@ const ALLOWED_PATH = ['/', '/account/restore-json'] as const;
 const PORT_CONTENT = 'content';
 const PHISHING_PAGE_REDIRECT = '/phishing-page-detected';
 const PORT_EXTENSION = 'extension';
-const PASSWORD_EXPIRY_MIN = 15;
+const PASSWORD_EXPIRY_MIN = 1;
 const PASSWORD_EXPIRY_MS = PASSWORD_EXPIRY_MIN * 60 * 1000;
 
 export {

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -5,7 +5,7 @@ const ALLOWED_PATH = ['/', '/account/restore-json'] as const;
 const PORT_CONTENT = 'content';
 const PHISHING_PAGE_REDIRECT = '/phishing-page-detected';
 const PORT_EXTENSION = 'extension';
-const PASSWORD_EXPIRY_MIN = 1;
+const PASSWORD_EXPIRY_MIN = 15;
 const PASSWORD_EXPIRY_MS = PASSWORD_EXPIRY_MIN * 60 * 1000;
 
 export {

--- a/packages/extension-ui/src/Popup/Signing/Request.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request.tsx
@@ -48,12 +48,20 @@ export default function Request ({ account: { isExternal }, buttonText, isFirst,
   const [isLocked, setIsLocked] = useState<boolean | null>(null);
   const [savePass, setSavePass] = useState(false);
 
-  useEffect((): void => {
+  useEffect(() => {
     setIsLocked(null);
+    let timeout: number;
 
     !isExternal && isSignLocked(signId)
-      .then((isLocked) => setIsLocked(isLocked))
+      .then(({ isLocked, remainingTime }) => {
+        setIsLocked(isLocked);
+        timeout = setTimeout(() => {
+          setIsLocked(true);
+        }, remainingTime);
+      })
       .catch((error: Error) => console.error(error));
+
+    return () => { !!timeout && clearTimeout(timeout); };
   }, [isExternal, signId]);
 
   useEffect((): void => {

--- a/packages/extension-ui/src/Popup/Signing/Request.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request.tsx
@@ -11,7 +11,7 @@ import { TypeRegistry } from '@polkadot/types';
 
 import { ActionBar, ActionContext, Address, Button, ButtonArea, Checkbox, Link, VerticalSpace } from '../../components';
 import useTranslation from '../../hooks/useTranslation';
-import { approveSignPassword, approveSignSignature, cancelSignRequest, isSignLocked, updatePasswordCache } from '../../messaging';
+import { approveSignPassword, approveSignSignature, cancelSignRequest, isSignLocked, refreshAccountPasswordCache } from '../../messaging';
 import Bytes from './Bytes';
 import Extrinsic from './Extrinsic';
 import Qr from './Qr';
@@ -49,7 +49,7 @@ export default function Request ({ account: { address, isExternal }, buttonText,
   const [savePass, setSavePass] = useState(false);
 
   useEffect(() => {
-    updatePasswordCache(address)
+    refreshAccountPasswordCache(address)
       .catch((e) => console.error(e));
   }, [address]);
 

--- a/packages/extension-ui/src/Popup/Signing/Request.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request.tsx
@@ -11,7 +11,7 @@ import { TypeRegistry } from '@polkadot/types';
 
 import { ActionBar, ActionContext, Address, Button, ButtonArea, Checkbox, Link, VerticalSpace } from '../../components';
 import useTranslation from '../../hooks/useTranslation';
-import { approveSignPassword, approveSignSignature, cancelSignRequest, isSignLocked, refreshAccountPasswordCache } from '../../messaging';
+import { approveSignPassword, approveSignSignature, cancelSignRequest, isSignLocked } from '../../messaging';
 import Bytes from './Bytes';
 import Extrinsic from './Extrinsic';
 import Qr from './Qr';
@@ -39,7 +39,7 @@ function isRawPayload (payload: SignerPayloadJSON | SignerPayloadRaw): payload i
   return !!(payload as SignerPayloadRaw).data;
 }
 
-export default function Request ({ account: { address, isExternal }, buttonText, isFirst, request, signId, url }: Props): React.ReactElement<Props> | null {
+export default function Request ({ account: { isExternal }, buttonText, isFirst, request, signId, url }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const onAction = useContext(ActionContext);
   const [{ hexBytes, payload }, setData] = useState<Data>({ hexBytes: null, payload: null });
@@ -47,11 +47,6 @@ export default function Request ({ account: { address, isExternal }, buttonText,
   const [isBusy, setIsBusy] = useState(false);
   const [isLocked, setIsLocked] = useState<boolean | null>(null);
   const [savePass, setSavePass] = useState(false);
-
-  useEffect(() => {
-    refreshAccountPasswordCache(address)
-      .catch((e) => console.error(e));
-  }, [address]);
 
   useEffect((): void => {
     setIsLocked(null);

--- a/packages/extension-ui/src/Popup/Signing/Unlock.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Unlock.tsx
@@ -52,6 +52,7 @@ function Unlock ({ buttonText, children, className, error, isBusy, onSign }: Pro
       {children}
       <Button
         isBusy={isBusy}
+        isDisabled={!password}
         onClick={_onClick}
       >
         {buttonText}

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Message } from '@polkadot/extension-base/types';
-import { AccountJson, AllowedPath, AuthorizeRequest, SigningRequest, RequestTypes, MessageTypes, ResponseTypes, SeedLengths, SubscriptionMessageTypes, MetadataRequest, MessageTypesWithNullRequest, MessageTypesWithNoSubscriptions, MessageTypesWithSubscriptions, ResponseDeriveValidate, ResponseJsonRestore } from '@polkadot/extension-base/background/types';
+import { AccountJson, AllowedPath, AuthorizeRequest, SigningRequest, RequestTypes, MessageTypes, ResponseTypes, SeedLengths, SubscriptionMessageTypes, MetadataRequest, MessageTypesWithNullRequest, MessageTypesWithNoSubscriptions, MessageTypesWithSubscriptions, ResponseDeriveValidate, ResponseJsonRestore, ResponseSigningIsLocked } from '@polkadot/extension-base/background/types';
 import { Chain } from '@polkadot/extension-chains/types';
 import { MetadataDef } from '@polkadot/extension-inject/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
@@ -101,7 +101,7 @@ export async function cancelSignRequest (id: string): Promise<boolean> {
   return sendMessage('pri(signing.cancel)', { id });
 }
 
-export async function isSignLocked (id: string): Promise<boolean> {
+export async function isSignLocked (id: string): Promise<ResponseSigningIsLocked> {
   return sendMessage('pri(signing.isLocked)', { id });
 }
 

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -69,8 +69,8 @@ export async function editAccount (address: string, name: string): Promise<boole
   return sendMessage('pri(accounts.edit)', { address, name });
 }
 
-export async function isAccountPasswordCached (address: string): Promise<boolean> {
-  return sendMessage('pri(accounts.passwordCached)', { address });
+export async function updatePasswordCache (address: string): Promise<void> {
+  return sendMessage('pri(accounts.passwordCacheUpdate)', { address });
 }
 
 export async function showAccount (address: string, isShowing: boolean): Promise<boolean> {

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -69,8 +69,8 @@ export async function editAccount (address: string, name: string): Promise<boole
   return sendMessage('pri(accounts.edit)', { address, name });
 }
 
-export async function updatePasswordCache (address: string): Promise<void> {
-  return sendMessage('pri(accounts.passwordCacheUpdate)', { address });
+export async function refreshAccountPasswordCache (address: string): Promise<void> {
+  return sendMessage('pri(accounts.refreshPasswordCache)', { address });
 }
 
 export async function showAccount (address: string, isShowing: boolean): Promise<boolean> {

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -69,10 +69,6 @@ export async function editAccount (address: string, name: string): Promise<boole
   return sendMessage('pri(accounts.edit)', { address, name });
 }
 
-export async function refreshAccountPasswordCache (address: string): Promise<void> {
-  return sendMessage('pri(accounts.refreshPasswordCache)', { address });
-}
-
 export async function showAccount (address: string, isShowing: boolean): Promise<boolean> {
   return sendMessage('pri(accounts.show)', { address, isShowing });
 }

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -69,6 +69,10 @@ export async function editAccount (address: string, name: string): Promise<boole
   return sendMessage('pri(accounts.edit)', { address, name });
 }
 
+export async function isAccountPasswordCached (address: string): Promise<boolean> {
+  return sendMessage('pri(accounts.passwordCached)', { address });
+}
+
 export async function showAccount (address: string, isShowing: boolean): Promise<boolean> {
   return sendMessage('pri(accounts.show)', { address, isShowing });
 }
@@ -105,8 +109,8 @@ export async function isSignLocked (id: string): Promise<boolean> {
   return sendMessage('pri(signing.isLocked)', { id });
 }
 
-export async function approveSignPassword (id: string, password: string, isSavedPass: boolean): Promise<boolean> {
-  return sendMessage('pri(signing.approve.password)', { id, isSavedPass, password });
+export async function approveSignPassword (id: string, savePass: boolean, password?: string): Promise<boolean> {
+  return sendMessage('pri(signing.approve.password)', { id, password, savePass });
 }
 
 export async function approveSignSignature (id: string, signature: string): Promise<boolean> {


### PR DESCRIPTION
- renaming to make things clear `savePass` is an action, whether the password is needed or not is told by the `isLocked` on the pair
- use an "updateCache" function that is called
  - when the Request popup loads (it is part of the flow when the UI calls `isLocked`)
  - right before signing to avoid the security issue of having the account unlocked potentially longer than the set period.
  - edit the Popup is aware of the cache duration and starts a timeout until the account gets locked. 
- ~~I've been testing the event when you open the popup request before the cache expires (no password needed) and wait until it expires --> signing will fail. The experience would be much better if we could update the UI. This is non trivial though because it would mean changing this `isLocked` from a pull to a subscription. Happy to do it in this PR, it's still small.~~
edit: addressed in https://github.com/polkadot-js/extension/pull/489/commits/72564b3314a213c456c1e03b2fa9ea8d9fd8ceb7