### PR TITLE
Refactor password error in request pop up and remember checkbox

### DIFF
--- a/packages/extension-ui/src/Popup/Signing/Request.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request.tsx
@@ -49,8 +49,6 @@ export default function Request ({ account: { isExternal }, buttonText, isFirst,
   const [savePass, setSavePass] = useState(false);
   const [password, setPassword] = useState('');
 
-  console.log('error', error);
-
   useEffect(() => {
     setIsLocked(null);
     let timeout: number;
@@ -58,7 +56,6 @@ export default function Request ({ account: { isExternal }, buttonText, isFirst,
     !isExternal && isSignLocked(signId)
       .then(({ isLocked, remainingTime }) => {
         setIsLocked(isLocked);
-        console.log('remaining time', remainingTime / 1000);
         timeout = setTimeout(() => {
           setIsLocked(true);
         }, remainingTime);

--- a/packages/extension-ui/src/Popup/Signing/Unlock.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Unlock.tsx
@@ -41,6 +41,7 @@ function Unlock ({ className, error, isBusy, onSign, password, setError, setPass
         onEnter={onSign}
         type='password'
         value={password}
+        withoutMargin={true}
       />
       {error && <div className='error'>{error}</div>}
     </div>

--- a/packages/extension-ui/src/Popup/Signing/Unlock.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Unlock.tsx
@@ -1,64 +1,56 @@
 // Copyright 2019-2020 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { ThemeProps } from '@polkadot/extension-ui/types';
 
-import { Button, InputWithLabel } from '../../components';
+import React, { useCallback } from 'react';
+import styled from 'styled-components';
+
+import { InputWithLabel } from '../../components';
 import useTranslation from '../../hooks/useTranslation';
 
-interface Props {
-  buttonText: string;
-  children?: React.ReactNode;
+interface Props extends ThemeProps {
   className?: string;
   error?: string | null;
   isBusy: boolean;
-  onSign: (password: string) => Promise<void>;
+  onSign: () => Promise<void>;
+  password: string;
+  setError: (error: string | null) => void;
+  setPassword: (password: string) => void;
 }
 
-function Unlock ({ buttonText, children, className, error, isBusy, onSign }: Props): React.ReactElement<Props> {
+function Unlock ({ className, error, isBusy, onSign, password, setError, setPassword }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const [ownError, setError] = useState<string | null>();
-  const [password, setPassword] = useState('');
-
-  useEffect((): void => {
-    setError(error || null);
-  }, [error]);
 
   const _onChangePassword = useCallback(
     (password: string): void => {
       setPassword(password);
       setError(null);
     },
-    []
-  );
-
-  const _onClick = useCallback(
-    () => onSign(password),
-    [onSign, password]
+    [setError, setPassword]
   );
 
   return (
     <div className={className}>
       <InputWithLabel
         disabled={isBusy}
-        isError={!password || !!ownError}
+        isError={!password || !!error}
         isFocused
         label={t<string>('Password for this account')}
         onChange={_onChangePassword}
-        onEnter={_onClick}
+        onEnter={onSign}
         type='password'
-        withoutMargin={!!children}
+        value={password}
       />
-      {children}
-      <Button
-        isBusy={isBusy}
-        isDisabled={!password}
-        onClick={_onClick}
-      >
-        {buttonText}
-      </Button>
+      {error && <div className='error'>{error}</div>}
     </div>
   );
 }
 
-export default React.memo(Unlock);
+export default React.memo(styled(Unlock)(({ theme }: ThemeProps) => `
+  .error {
+    font-size: ${theme.labelFontSize};
+    line-height: ${theme.labelLineHeight};
+    color: ${theme.errorColor};
+  }
+`));

--- a/packages/extension-ui/src/components/InputWithLabel.tsx
+++ b/packages/extension-ui/src/components/InputWithLabel.tsx
@@ -21,9 +21,10 @@ interface Props {
   placeholder?: string;
   type?: 'text' | 'password';
   value?: string;
+  withoutMargin?: boolean;
 }
 
-function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused, isReadOnly, label = '', onBlur, onChange, onEnter, placeholder, type = 'text', value }: Props): React.ReactElement<Props> {
+function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused, isReadOnly, label = '', onBlur, onChange, onEnter, placeholder, type = 'text', value, withoutMargin }: Props): React.ReactElement<Props> {
   const _checkEnter = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>): void => {
       onEnter && event.key === 'Enter' && onEnter();
@@ -40,7 +41,7 @@ function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused
 
   return (
     <Label
-      className={className}
+      className={`${className || ''} ${withoutMargin ? 'withoutMargin' : ''}`}
       label={label}
     >
       <Input
@@ -65,4 +66,8 @@ function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused
 
 export default styled(InputWithLabel)`
   margin-bottom: 16px;
+
+  &.withoutMargin {
+    margin-bottom: 0px;
+  }
 `;

--- a/packages/extension-ui/src/components/InputWithLabel.tsx
+++ b/packages/extension-ui/src/components/InputWithLabel.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback } from 'react';
+import styled from 'styled-components';
 
 import Label from './Label';
 import { Input } from './TextInputs';
@@ -22,7 +23,7 @@ interface Props {
   value?: string;
 }
 
-function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused, isReadOnly, label, onBlur, onChange, onEnter, placeholder, type = 'text', value }: Props): React.ReactElement<Props> {
+function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused, isReadOnly, label = '', onBlur, onChange, onEnter, placeholder, type = 'text', value }: Props): React.ReactElement<Props> {
   const _checkEnter = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>): void => {
       onEnter && event.key === 'Enter' && onEnter();
@@ -62,4 +63,6 @@ function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused
   );
 }
 
-export default InputWithLabel;
+export default styled(InputWithLabel)`
+  margin-bottom: 16px;
+`;

--- a/packages/extension-ui/src/components/InputWithLabel.tsx
+++ b/packages/extension-ui/src/components/InputWithLabel.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback } from 'react';
-import styled from 'styled-components';
 
 import Label from './Label';
 import { Input } from './TextInputs';
@@ -21,7 +20,6 @@ interface Props {
   placeholder?: string;
   type?: 'text' | 'password';
   value?: string;
-  withoutMargin?: boolean;
 }
 
 function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused, isReadOnly, label, onBlur, onChange, onEnter, placeholder, type = 'text', value }: Props): React.ReactElement<Props> {
@@ -64,6 +62,4 @@ function InputWithLabel ({ className, defaultValue, disabled, isError, isFocused
   );
 }
 
-export default styled(InputWithLabel)(({ withoutMargin }: Props) => `
-  margin-bottom: ${withoutMargin ? 0 : 16}px;
-`);
+export default InputWithLabel;


### PR DESCRIPTION
closes https://github.com/polkadot-js/extension/issues/487
closes https://github.com/polkadot-js/extension/issues/494
closes https://github.com/polkadot-js/extension/issues/491

- checkbox checked by default to extend the "password remember" period. Wording suggestion welcome :)
- unchecking this checkbox will lock the account after this last signature (so it's either extend, or lock after this one)

Here is a demo
- I first enter a wrong password twice, then type the right one and set to remember the password for 15min
- submit another tx, the password isn't needed, the checkbox to extend is checked, I uncheck it
- submit another tx -> password is asked.

![remember](https://user-images.githubusercontent.com/33178835/96147784-e8cf0080-0f07-11eb-9041-73dfc1e37cff.gif)
