### PR TITLE
Fix scanner config (parse .ts files)

### DIFF
--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -8,7 +8,7 @@ const typescript = require('typescript');
 function transform (file, enc, done) {
   const { ext } = path.parse(file.path);
 
-  if (ext === '.tsx') {
+  if (['.ts', '.tsx'].includes(ext)) {
     const content = fs.readFileSync(file.path, enc);
 
     const { outputText } = typescript.transpileModule(content, {


### PR DESCRIPTION
Same fix as in apps.

This config probably needs to move into dev and can then just be included (like we do for eg babel/jest/ts/etc)