### PR TITLE
Remove scrollbar on signing popup

### DIFF
--- a/packages/extension-ui/src/components/Table.tsx
+++ b/packages/extension-ui/src/components/Table.tsx
@@ -31,7 +31,7 @@ export default React.memo(styled(Table)(({ theme }: ThemeProps) => `
 
   &.isFull {
     height: 100%;
-    overflow: scroll;
+    overflow: auto;
   }
 
   td.data {


### PR DESCRIPTION
Simple, yet triggering my OCD each time :)
Tested that the scrollbar appears with longer content on FF and Chrome.

This make it look like the screenshot in #510
![image](https://user-images.githubusercontent.com/33178835/96574964-6dd36480-12d0-11eb-9f35-90358197b7a9.png)
With longer content (manually added many lines to simulate a longer content)
![image](https://user-images.githubusercontent.com/33178835/96575080-96f3f500-12d0-11eb-825a-f0ccba754bdf.png)


instead of having disabled scrollbar like before:
![image](https://user-images.githubusercontent.com/33178835/96575007-7deb4400-12d0-11eb-8996-e4abd1720810.png)
