### PR TITLE
Remove deprecated util-crypto setSS58Format

### DIFF
--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -8,7 +8,6 @@ import React, { useEffect, useState } from 'react';
 import { Route, Switch } from 'react-router';
 import { PHISHING_PAGE_REDIRECT } from '@polkadot/extension-base/defaults';
 import uiSettings from '@polkadot/ui-settings';
-import { setSS58Format } from '@polkadot/util-crypto';
 
 import { Loading, ErrorBoundary } from '../components';
 import { AccountContext, ActionContext, AuthorizeReqContext, MediaContext, MetadataReqContext, SettingsContext, SigningReqContext } from '../components/contexts';
@@ -89,7 +88,6 @@ export default function Popup (): React.ReactElement {
     uiSettings.on('change', (settings): void => {
       setSettingsCtx(settings);
       setCameraOn(settings.camera === 'on');
-      setSS58Format(settings.prefix === -1 ? 42 : settings.prefix);
     });
 
     _onAction();


### PR DESCRIPTION
Not 100% aware of the implication of this, but from what I could see there are no other implication.
We are passing the account meta (including the relevant `genesisHash`) in all our account creation methods (checked mnemonic, derive and JSON). Otherwise it'll default to substrate (42). All in all, it seems that it is only a UI thing.