### PR TITLE
Set popup window height to 600px

### DIFF
--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -59,7 +59,7 @@ let idCounter = 0;
 const WINDOW_OPTS = {
   // This is not allowed on FF, only on Chrome - disable completely
   // focused: true,
-  height: 621,
+  height: 600,
   left: 150,
   top: 150,
   type: 'popup',


### PR DESCRIPTION
I remember there was something special about this window height, but I can recall what it was and the internet didn't give me the answer.

In any case, this fix removes this white band at the bottom of any popup. It hadn't attract my eye so far.. and I thought I introduced it in #518 but it's also there on the live 0.34..

![image](https://user-images.githubusercontent.com/33178835/96956283-ff70eb00-14f7-11eb-8a87-fd64584d0d23.png)
