### PR TITLE
Fix error field being shown before entering any name

### DIFF
--- a/packages/extension-ui/src/Popup/CreateAccount/CreateAccount.test.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/CreateAccount.test.tsx
@@ -85,6 +85,7 @@ describe('Create Account', () => {
       check(wrapper.find('input[type="checkbox"]'));
       wrapper.find('button').simulate('click');
       await act(flushAllPromises);
+      wrapper.update();
     });
 
     it('only account name input is visible at first', () => {

--- a/packages/extension-ui/src/components/ValidatedInput.tsx
+++ b/packages/extension-ui/src/components/ValidatedInput.tsx
@@ -6,6 +6,7 @@ import { ThemeProps } from '../types';
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
+import useIsMounted from '../hooks/useIsMounted';
 import { Result, Validator } from '../util/validators';
 
 interface BasicProps {
@@ -24,13 +25,12 @@ type Props<T extends BasicProps> = T & {
 
 function ValidatedInput<T extends Record<string, unknown>> ({ className, component: Input, defaultValue, onValidatedChange, validator, ...props }: Props<T>): React.ReactElement<Props<T>> {
   const [value, setValue] = useState(defaultValue || '');
-  const [wasMounted, setWasMounted] = useState(false);
   const [validationResult, setValidationResult] = useState<Result<string>>(Result.ok(''));
+  const isMounted = useIsMounted();
 
   useEffect(() => {
-    if (!wasMounted) {
-      setWasMounted(true);
-
+    // Do not show any error on first mount
+    if (!isMounted) {
       return;
     }
 

--- a/packages/extension-ui/src/components/ValidatedInput.tsx
+++ b/packages/extension-ui/src/components/ValidatedInput.tsx
@@ -30,6 +30,8 @@ function ValidatedInput<T extends Record<string, unknown>> ({ className, compone
   useEffect(() => {
     if (!wasMounted) {
       setWasMounted(true);
+
+      return;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/extension-ui/src/hooks/useIsMounted.ts
+++ b/packages/extension-ui/src/hooks/useIsMounted.ts
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useRef } from 'react';
+
+export default function useIsMounted (): boolean {
+  const isMounted = useRef(false);
+
+  useEffect((): () => void => {
+    isMounted.current = true;
+
+    return (): void => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted.current;
+}


### PR DESCRIPTION
closes #517 

Took me forever to notice the missing `update()` in tests and make it fail.

Interestingly, the `return` added was part of the original PR https://github.com/polkadot-js/extension/pull/299/files#diff-5ba6606e2d09b06b1994e7f7388db063bf6bb3c10bc603dd5b097bcbb61da6f9R31 and github blame doesn't show me when this was deleted, it'd be a valuable information to know if it's a mistake or if there was a good reason to do so.