### PR TITLE
Window height back to 621 and set 100%

### DIFF
--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -59,7 +59,7 @@ let idCounter = 0;
 const WINDOW_OPTS = {
   // This is not allowed on FF, only on Chrome - disable completely
   // focused: true,
-  height: 600,
+  height: 621,
   left: 150,
   top: 150,
   type: 'popup',

--- a/packages/extension/public/index.html
+++ b/packages/extension/public/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="height: 100%; width:560px; min-height: 600px;">
   <head>
     <meta charset="utf-8">
     <title>polkadot{.js}</title>
     <link href="fonts/fonts.css" rel="stylesheet">
   </head>
-  <body style="height: 600px; margin:0; overflow-x:hidden; text-align:center">
+  <body style="min-height: 600px; height: 100%; margin:0; overflow-x:hidden; text-align:center">
     <div id="root" style="box-sizing:border-box; margin:0 auto; padding:0; text-align:left; width:560px; height: calc(100% - 2px); max-width: 100%;"></div>
     <script src='./extension.js'></script>
   </body>

--- a/packages/extension/public/index.html
+++ b/packages/extension/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" style="height: 100%; width:560px; min-height: 600px;">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>polkadot{.js}</title>


### PR DESCRIPTION
following #520 

- The external window is now back to 621px, the popup is still 600px as before.
- I've set a couple `height:100%` to prevent the empty space at the bottom that made me propose #520. 
- This `min-height 600px` was necessary for the poup to be at 600 (it was all shrink otherwise).
- Looks good on FF and Chrome although interestingly the popup is 620 on Firefox, not 621

![Selection_349](https://user-images.githubusercontent.com/33178835/99991519-66164c80-2db5-11eb-86d6-cc1cf0402d9f.png)
![Selection_350](https://user-images.githubusercontent.com/33178835/99991524-6878a680-2db5-11eb-9881-c9ac2a214eeb.png)
