### PR TITLE
Add a dedicated notification index

### DIFF
--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -63,7 +63,7 @@ const WINDOW_OPTS = {
   left: 150,
   top: 150,
   type: 'popup',
-  url: chrome.extension.getURL('index.html'),
+  url: chrome.extension.getURL('notification.html'),
   width: 560
 };
 

--- a/packages/extension/public/index.html
+++ b/packages/extension/public/index.html
@@ -5,7 +5,7 @@
     <title>polkadot{.js}</title>
     <link href="fonts/fonts.css" rel="stylesheet">
   </head>
-  <body style="min-height: 600px; height: 100%; margin:0; overflow-x:hidden; text-align:center">
+  <body style="height: 600px; margin:0; overflow-x:hidden; text-align:center">
     <div id="root" style="box-sizing:border-box; margin:0 auto; padding:0; text-align:left; width:560px; height: calc(100% - 2px); max-width: 100%;"></div>
     <script src='./extension.js'></script>
   </body>

--- a/packages/extension/public/notification.html
+++ b/packages/extension/public/notification.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>polkadot{.js}</title>
+    <link href="fonts/fonts.css" rel="stylesheet">
+  </head>
+  <body style="height: 621px; margin:0; overflow-x:hidden; text-align:center">
+    <div id="root" style="box-sizing:border-box; margin:0 auto; padding:0; text-align:left; width:560px; height: calc(100% - 2px); max-width: 100%;"></div>
+    <script src='./extension.js'></script>
+  </body>
+</html>


### PR DESCRIPTION
This gets us, I think to the best possible scenario, where the notification window is set to 621px, no white bar for me, the extension popup (when clicking the icon) is fixed 600px and scrollable.

For the record, an extension popup windows (when clicking the icon) can't be higher than 600px.