### PR TITLE
Use account info to retrieve genesisHash in forget or export

### DIFF
--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -44,6 +44,7 @@ interface Props {
 interface Recoded {
   account: AccountJson | null;
   formatted: string | null;
+  genesisHash?: string | null;
   prefix: number;
 }
 
@@ -69,6 +70,7 @@ function recodeAddress (address: string, accounts: AccountWithChildren[], chain:
   return {
     account,
     formatted: encodeAddress(publicKey, prefix),
+    genesisHash: account?.genesisHash,
     prefix
   };
 }
@@ -79,8 +81,9 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
   const { t } = useTranslation();
   const { accounts } = useContext(AccountContext);
   const settings = useContext(SettingsContext);
-  const chain = useMetadata(genesisHash, true);
-  const [{ account, formatted, prefix }, setRecoded] = useState<Recoded>({ account: null, formatted: null, prefix: 42 });
+  const [{ account, formatted, genesisHash: recodedGenesis, prefix }, setRecoded] = useState<Recoded>({ account: null, formatted: null, prefix: 42 });
+  const chain = useMetadata(genesisHash || recodedGenesis, true);
+
   const [showActionsMenu, setShowActionsMenu] = useState(false);
   const [moveMenuUp, setIsMovedMenu] = useState(false);
   const actionsRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
closes #574

I'll log an issue, it'd help a lot to have test on such complex and important components as `Address`

![chain](https://user-images.githubusercontent.com/33178835/101896320-1c957200-3ba9-11eb-87d6-b7e1b3e6fead.gif)