### PR TITLE
Prevent eth accounts to be selected for derivation

### DIFF
--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -9,6 +9,7 @@ import type { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 import type { MessageTypes, RequestAccountList, RequestAuthorizeTab, RequestRpcSend, RequestRpcSubscribe, RequestRpcUnsubscribe, RequestTypes, ResponseRpcListProviders, ResponseSigning, ResponseTypes, SubscriptionMessageTypes } from '../types';
 
 import { PHISHING_PAGE_REDIRECT } from '@polkadot/extension-base/defaults';
+import { canDerive } from '@polkadot/extension-base/utils';
 import { checkIfDenied } from '@polkadot/phishing';
 import keyring from '@polkadot/ui-keyring';
 import { accounts as accountsObservable } from '@polkadot/ui-keyring/observable/accounts';
@@ -23,7 +24,7 @@ function transformAccounts (accounts: SubjectInfo, anyType = false): InjectedAcc
   return Object
     .values(accounts)
     .filter(({ json: { meta: { isHidden } } }) => !isHidden)
-    .filter(({ type }) => anyType ? true : type && ['ed25519', 'sr25519', 'ecdsa'].includes(type))
+    .filter(({ type }) => anyType ? true : canDerive(type))
     .sort((a, b) => (a.json.meta.whenCreated || 0) - (b.json.meta.whenCreated || 0))
     .map(({ json: { address, meta: { genesisHash, name } }, type }): InjectedAccount => ({
       address,

--- a/packages/extension-base/src/utils/canDerive.ts
+++ b/packages/extension-base/src/utils/canDerive.ts
@@ -1,0 +1,8 @@
+// Copyright 2019-2020 @polkadot/extension authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { KeypairType } from '@polkadot/util-crypto/types';
+
+export default function canDerive (type?: KeypairType): boolean {
+  return !!type && ['ed25519', 'sr25519', 'ecdsa'].includes(type);
+}

--- a/packages/extension-base/src/utils/index.ts
+++ b/packages/extension-base/src/utils/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2019-2020 @polkadot/extension authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export { default as canDerive } from './canDerive';

--- a/packages/extension-ui/src/Popup/Accounts/Account.test.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.test.tsx
@@ -49,12 +49,13 @@ describe('Account component', () => {
     expect(wrapper.find('a.menuItem').at(1).text()).toBe('Forget Account');
   });
 
-  it('does not show Export option if account is ethereum type', () => {
-    wrapper = mountAccountComponent({ isExternal: true, type: 'ethereum' });
+  it('does not show Derive option if account is of ethereum type', () => {
+    wrapper = mountAccountComponent({ isExternal: false, type: 'ethereum' });
     wrapper.find('.settings').first().simulate('click');
 
-    expect(wrapper.find('a.menuItem').length).toBe(2);
+    expect(wrapper.find('a.menuItem').length).toBe(3);
     expect(wrapper.find('a.menuItem').at(0).text()).toBe('Rename');
-    expect(wrapper.find('a.menuItem').at(1).text()).toBe('Forget Account');
+    expect(wrapper.find('a.menuItem').at(1).text()).toBe('Export Account');
+    expect(wrapper.find('a.menuItem').at(2).text()).toBe('Forget Account');
   });
 });

--- a/packages/extension-ui/src/Popup/Accounts/Account.test.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.test.tsx
@@ -30,7 +30,7 @@ describe('Account component', () => {
     </MemoryRouter>);
 
   it('shows Export option if account is not external', () => {
-    wrapper = mountAccountComponent({ isExternal: false });
+    wrapper = mountAccountComponent({ isExternal: false, type: 'ed25519' });
     wrapper.find('.settings').first().simulate('click');
 
     expect(wrapper.find('a.menuItem').length).toBe(4);
@@ -41,7 +41,16 @@ describe('Account component', () => {
   });
 
   it('does not show Export option if account is external', () => {
-    wrapper = mountAccountComponent({ isExternal: true });
+    wrapper = mountAccountComponent({ isExternal: true, type: 'ed25519' });
+    wrapper.find('.settings').first().simulate('click');
+
+    expect(wrapper.find('a.menuItem').length).toBe(2);
+    expect(wrapper.find('a.menuItem').at(0).text()).toBe('Rename');
+    expect(wrapper.find('a.menuItem').at(1).text()).toBe('Forget Account');
+  });
+
+  it('does not show Export option if account is ethereum type', () => {
+    wrapper = mountAccountComponent({ isExternal: true, type: 'ethereum' });
     wrapper.find('.settings').first().simulate('click');
 
     expect(wrapper.find('a.menuItem').length).toBe(2);

--- a/packages/extension-ui/src/Popup/Accounts/Account.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.tsx
@@ -62,7 +62,7 @@ function Account ({ address, className, genesisHash, isExternal, isHidden, paren
       >
         {t<string>('Rename')}
       </Link>
-      {!isExternal && type !== 'ethereum' && (
+      {!isExternal && type && ['ed25519', 'sr25519', 'ecdsa'].includes(type) && (
         <Link
           className='menuItem'
           to={`/account/derive/${address}/locked`}

--- a/packages/extension-ui/src/Popup/Accounts/Account.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.tsx
@@ -6,6 +6,7 @@ import type { AccountJson } from '@polkadot/extension-base/background/types';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
+import { canDerive } from '@polkadot/extension-base/utils';
 import genesisOptions from '@polkadot/extension-chains/genesisHashes';
 
 import { ActionContext, Address, Dropdown, Link, MenuDivider } from '../../components';
@@ -62,7 +63,7 @@ function Account ({ address, className, genesisHash, isExternal, isHidden, paren
       >
         {t<string>('Rename')}
       </Link>
-      {!isExternal && type && ['ed25519', 'sr25519', 'ecdsa'].includes(type) && (
+      {!isExternal && canDerive(type) && (
         <Link
           className='menuItem'
           to={`/account/derive/${address}/locked`}

--- a/packages/extension-ui/src/Popup/Derive/Derive.test.tsx
+++ b/packages/extension-ui/src/Popup/Derive/Derive.test.tsx
@@ -3,7 +3,7 @@
 
 import '../../../../../__mocks__/chrome';
 
-import type { ResponseDeriveValidate } from '@polkadot/extension-base/background/types';
+import type { AccountJson, ResponseDeriveValidate } from '@polkadot/extension-base/background/types';
 
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { configure, mount, ReactWrapper } from 'enzyme';
@@ -23,13 +23,13 @@ import Derive from '.';
 configure({ adapter: new Adapter() });
 
 const accounts = [
-  { address: '5FjgD3Ns2UpnHJPVeRViMhCttuemaRXEqaD8V5z4vxcsUByA', name: 'A' },
-  { address: '5GYmFzQCuC5u3tQNiMZNbFGakrz3Jq31NmMg4D2QAkSoQ2g5', name: 'B' },
-  { address: '5D2TPhGEy2FhznvzaNYW9AkuMBbg3cyRemnPsBvBY4ZhkZXA', name: 'BB', parentAddress: '5GYmFzQCuC5u3tQNiMZNbFGakrz3Jq31NmMg4D2QAkSoQ2g5' },
-  { address: '5GhGENSJBWQZ8d8mARKgqEkiAxiW3hHeznQDW2iG4XzNieb6', isExternal: true, name: 'C' },
-  { address: '5EeaoDj4VDk8V6yQngKBaCD5MpJUCHrhYjVhBjgMHXoYon1s', isExternal: false, name: 'D' },
-  { address: '5HRKYp5anSNGtqC7cq9ftiaq4y8Mk7uHk7keaXUrQwZqDWLJ', name: 'DD', parentAddress: '5EeaoDj4VDk8V6yQngKBaCD5MpJUCHrhYjVhBjgMHXoYon1s' }
-];
+  { address: '5FjgD3Ns2UpnHJPVeRViMhCttuemaRXEqaD8V5z4vxcsUByA', name: 'A', type: 'sr25519' },
+  { address: '5GYmFzQCuC5u3tQNiMZNbFGakrz3Jq31NmMg4D2QAkSoQ2g5', name: 'B', type: 'sr25519' },
+  { address: '5D2TPhGEy2FhznvzaNYW9AkuMBbg3cyRemnPsBvBY4ZhkZXA', name: 'BB', parentAddress: '5GYmFzQCuC5u3tQNiMZNbFGakrz3Jq31NmMg4D2QAkSoQ2g5', type: 'sr25519' },
+  { address: '5GhGENSJBWQZ8d8mARKgqEkiAxiW3hHeznQDW2iG4XzNieb6', isExternal: true, name: 'C', type: 'sr25519' },
+  { address: '5EeaoDj4VDk8V6yQngKBaCD5MpJUCHrhYjVhBjgMHXoYon1s', isExternal: false, name: 'D', type: 'sr25519' },
+  { address: '5HRKYp5anSNGtqC7cq9ftiaq4y8Mk7uHk7keaXUrQwZqDWLJ', name: 'DD', parentAddress: '5EeaoDj4VDk8V6yQngKBaCD5MpJUCHrhYjVhBjgMHXoYon1s', type: 'sr25519' }
+] as AccountJson[];
 
 describe('Derive', () => {
   const mountComponent = async (locked = false): Promise<{

--- a/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
+++ b/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
@@ -38,9 +38,12 @@ function SelectParent ({ className, isLocked, onDerivationConfirmed, parentAddre
   const allAddresses = useMemo(
     () => hierarchy
       .filter(({ isExternal }) => !isExternal)
+      .filter(({ type }) => type !== 'ethereum')
       .map(({ address, genesisHash }): [string, string | null] => [address, genesisHash || null]),
     [hierarchy]
   );
+
+  console.log('allAddrfes', allAddresses);
 
   const _goCreate = useCallback(
     () => onAction('/account/create'),

--- a/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
+++ b/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
@@ -6,6 +6,7 @@ import type { ThemeProps } from '../../types';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
+import { canDerive } from '@polkadot/extension-base/utils';
 import { assert } from '@polkadot/util';
 
 import { AccountContext, ActionContext, Address, ButtonArea, Checkbox, InputWithLabel, Label, NextStepButton, VerticalSpace, Warning } from '../../components';
@@ -38,7 +39,7 @@ function SelectParent ({ className, isLocked, onDerivationConfirmed, parentAddre
   const allAddresses = useMemo(
     () => hierarchy
       .filter(({ isExternal }) => !isExternal)
-      .filter(({ type }) => type && ['ed25519', 'sr25519', 'ecdsa'].includes(type))
+      .filter(({ type }) => canDerive(type))
       .map(({ address, genesisHash }): [string, string | null] => [address, genesisHash || null]),
     [hierarchy]
   );

--- a/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
+++ b/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
@@ -43,8 +43,6 @@ function SelectParent ({ className, isLocked, onDerivationConfirmed, parentAddre
     [hierarchy]
   );
 
-  console.log('allAddrfes', allAddresses);
-
   const _goCreate = useCallback(
     () => onAction('/account/create'),
     [onAction]

--- a/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
+++ b/packages/extension-ui/src/Popup/Derive/SelectParent.tsx
@@ -38,7 +38,7 @@ function SelectParent ({ className, isLocked, onDerivationConfirmed, parentAddre
   const allAddresses = useMemo(
     () => hierarchy
       .filter(({ isExternal }) => !isExternal)
-      .filter(({ type }) => type !== 'ethereum')
+      .filter(({ type }) => type && ['ed25519', 'sr25519', 'ecdsa'].includes(type))
       .map(({ address, genesisHash }): [string, string | null] => [address, genesisHash || null]),
     [hierarchy]
   );

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useState } from 'react';
 import { Route, Switch } from 'react-router';
 
 import { PHISHING_PAGE_REDIRECT } from '@polkadot/extension-base/defaults';
+import { canDerive } from '@polkadot/extension-base/utils';
 import uiSettings from '@polkadot/ui-settings';
 
 import { ErrorBoundary, Loading } from '../components';
@@ -51,7 +52,7 @@ async function requestMediaAccess (cameraOn: boolean): Promise<boolean> {
 
 function initAccountContext (accounts: AccountJson[]): AccountsContext {
   const hierarchy = buildHierarchy(accounts);
-  const master = hierarchy.find(({ isExternal, type }) => !isExternal && type && ['ed25519', 'sr25519', 'ecdsa'].includes(type));
+  const master = hierarchy.find(({ isExternal, type }) => !isExternal && canDerive(type));
 
   return {
     accounts,

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -51,7 +51,7 @@ async function requestMediaAccess (cameraOn: boolean): Promise<boolean> {
 
 function initAccountContext (accounts: AccountJson[]): AccountsContext {
   const hierarchy = buildHierarchy(accounts);
-  const master = hierarchy.find((account) => !account.isExternal);
+  const master = hierarchy.find((account) => !account.isExternal && account.type !== 'ethereum');
 
   return {
     accounts,

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -51,7 +51,7 @@ async function requestMediaAccess (cameraOn: boolean): Promise<boolean> {
 
 function initAccountContext (accounts: AccountJson[]): AccountsContext {
   const hierarchy = buildHierarchy(accounts);
-  const master = hierarchy.find((account) => !account.isExternal && account.type !== 'ethereum');
+  const master = hierarchy.find(({ isExternal, type }) => !isExternal && type && ['ed25519', 'sr25519', 'ecdsa'].includes(type));
 
   return {
     accounts,


### PR DESCRIPTION
An oversight from #560
We were still able to select an eth account as parent, and the `master` account, which is the default one selected when using the general "derivation menu" defaulted to the first account in the hierarchy, which could have been an eth one. 