### PR TITLE
Some more tests for the Address component

### DIFF
--- a/packages/extension-ui/src/components/Address.test.tsx
+++ b/packages/extension-ui/src/components/Address.test.tsx
@@ -46,8 +46,8 @@ const accounts = [
 ] as AccountTestJson[];
 
 // With Westend genesis Hash
-// This account isn't part of the generic test because Westend isn't a built in netwokr
-// The label would only be displayed if the corresponding metadata are known
+// This account isn't part of the generic test because Westend isn't a built in network
+// The network would only be displayed if the corresponding metadata are known
 const westEndAccount = {
   address: 'Cs2LLqQ6DSRx8UPdVp6jny4DvwNqziBSowSu5Nb1u3R6Z7X',
   expectedEncodedAddress: '5CMQg2VXTrRWCUewro13qqc45Lf93KtzzS6hWR6dY6pvMZNF',

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -25,6 +25,7 @@ import useToast from '../hooks/useToast';
 import useTranslation from '../hooks/useTranslation';
 import { showAccount } from '../messaging';
 import { DEFAULT_TYPE } from '../util/defaultType';
+import getParentNameSuri from '../util/getParentNameSuri';
 import { AccountContext, SettingsContext } from './contexts';
 import Identicon from './Identicon';
 import Menu from './Menu';
@@ -167,7 +168,7 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
       </>);
   };
 
-  const parentNameSuri = `${parentName || ''}  ${suri || ''}`;
+  const parentNameSuri = getParentNameSuri(parentName, suri);
 
   return (
     <div className={className}>

--- a/packages/extension-ui/src/util/getParentNameSuri.ts
+++ b/packages/extension-ui/src/util/getParentNameSuri.ts
@@ -1,0 +1,6 @@
+// Copyright 2019-2020 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export default function (parentName?: string | null, suri?: string): string {
+  return `${parentName || ''}  ${suri || ''}`;
+}


### PR DESCRIPTION
we've now covered most use-cases I think with:
- showing info from metadata (happens on signing popup)
- showing parent info (on main account overview only)