### PR TITLE
Remove current tab and open landing page

### DIFF
--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -145,11 +145,12 @@ export default class Tabs {
     const encodedWebsite = encodeURIComponent(phishingWebsite);
     const url = `${chrome.extension.getURL('index.html')}#${PHISHING_PAGE_REDIRECT}/${encodedWebsite}`;
 
-    chrome.tabs.query({ active: true, currentWindow: true, windowType: 'normal' }, (tabs) => {
-      const currentTabId = tabs[0].id;
-
-      currentTabId && chrome.tabs.remove(currentTabId, () => {
-        chrome.tabs.create({ active: true, url });
+    chrome.tabs.query({ currentWindow: true }, (tabs) => {
+      tabs.forEach((tab) => {
+        if (tab.url === phishingWebsite) {
+          tab.id && chrome.tabs.remove(tab.id);
+          chrome.tabs.create({ active: true, url });
+        }
       });
     });
 

--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -145,7 +145,13 @@ export default class Tabs {
     const encodedWebsite = encodeURIComponent(phishingWebsite);
     const url = `${chrome.extension.getURL('index.html')}#${PHISHING_PAGE_REDIRECT}/${encodedWebsite}`;
 
-    chrome.tabs.update({ url });
+    chrome.tabs.query({ active: true, currentWindow: true, windowType: 'normal' }, (tabs) => {
+      const currentTabId = tabs[0].id;
+
+      currentTabId && chrome.tabs.remove(currentTabId, () => {
+        chrome.tabs.create({ active: true, url });
+      });
+    });
 
     return null;
   }

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -5,7 +5,7 @@
   "name": "polkadot{.js} extension",
   "short_name": "polkadot{.js}",
   "manifest_version": 2,
-  "permissions": ["storage"],
+  "permissions": ["storage", "tabs"],
   "background": {
     "scripts": ["background.js"],
     "persistent": true


### PR DESCRIPTION
This behavior is a tiny bit better in that it shows the landing page first, because it gets opened in a new active tab. The phishing website is still there in another tab though.

I've experimented with `chrome.tabs.query` such as: 
```
 chrome.tabs.query({ currentWindow: true, url: phishingWebsite }, (res) => { console.log('res', res); })
```
but for some reason, the `res` is always empty if the website is opened in a new tab