### PR TITLE
✨ allows background handler to handle custom extention port name

### DIFF
--- a/packages/extension-base/src/background/handlers/index.ts
+++ b/packages/extension-base/src/background/handlers/index.ts
@@ -14,8 +14,8 @@ const state = new State();
 const extension = new Extension(state);
 const tabs = new Tabs(state);
 
-export default function handler<TMessageType extends MessageTypes> ({ id, message, request }: TransportRequestMessage<TMessageType>, port: chrome.runtime.Port): void {
-  const isExtension = port.name === PORT_EXTENSION;
+export default function handler<TMessageType extends MessageTypes> ({ id, message, request }: TransportRequestMessage<TMessageType>, port: chrome.runtime.Port, extensionPortName = PORT_EXTENSION): void {
+  const isExtension = port.name === extensionPortName;
   const sender = port.sender as chrome.runtime.MessageSender;
   const from = isExtension
     ? 'extension'


### PR DESCRIPTION
Our custom wallet delegates handling of standard messages to polkadot-js library. The hard-coded reference to `PORT_EXTENSION` create a port name collision when users have multiple wallets installed. This change will allow us to provide the polkadot-js handler with our wallet's custom port name to avoid this collision.

Our target usecase: https://github.com/PolymathNetwork/polymesh-wallet/pull/126/files#diff-fdfafa0e47eeeae377557dd534aa80a02af8257fb509ab33f2d44b296e2b5bddL37