### PR TITLE
Prevent unauthorized apps from abusing pub(authorize.tab) request

### DIFF
--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -295,6 +295,12 @@ export default class State {
   public async authorizeUrl (url: string, request: RequestAuthorizeTab): Promise<boolean> {
     const idStr = this.stripUrl(url);
 
+    // Do not enqueue duplicate authorization requests.
+    const isDuplicate = Object.values(this.#authRequests)
+      .some((request) => request.idStr === idStr);
+
+    assert(!isDuplicate, `The source ${url} has a pending authorization request`);
+
     if (this.#authUrls[idStr]) {
       // this url was seen in the past
       assert(this.#authUrls[idStr].isAllowed, `The source ${url} is not allowed to interact with this extension`);


### PR DESCRIPTION
An unauthorized app may send a large number of the "pub(authorize.tab)" request in a row to cause a denial of service, since each request launches a new popup. The app might send this request in a large volume that extension user never gets a chance to approve or reject those requests.