### PR TITLE
Remove window sizes from window opts

### DIFF
--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -60,14 +60,9 @@ interface SignRequest extends Resolver<ResponseSigning> {
 let idCounter = 0;
 
 const WINDOW_OPTS: chrome.windows.CreateData = {
-  // This is not allowed on FF, only on Chrome - disable completely
-  // focused: true,
-  height: 621,
-  left: 150,
-  top: 150,
+  focused: true,
   type: 'popup',
-  url: chrome.extension.getURL('notification.html'),
-  width: 560
+  url: chrome.extension.getURL('notification.html')
 };
 
 const AUTH_URLS_KEY = 'authUrls';


### PR DESCRIPTION
These window sizes have really poor behaviors (at least on MacOS using Firefox).

Without such specifications, users can control the window sizing on their own, and the browser will remember the size and location from previous.

Def recommend removing them.