### PR TITLE
Add list of ethereum networks

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -297,7 +297,10 @@ export default class Extension {
   }
 
   private seedCreate ({ length = SEED_DEFAULT_LENGTH, type }: RequestSeedCreate): ResponseSeedCreate {
-    const seed = mnemonicGenerate(length);
+    let seed = mnemonicGenerate(length);
+    if (type==="ethereum"){
+      seed+=`/m/44'/60'/0'/0/0`
+    }
 
     return {
       address: keyring.createFromUri(seed, {}, type).address,

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -22,6 +22,9 @@ type CachedUnlocks = Record<string, number>;
 
 const SEED_DEFAULT_LENGTH = 12;
 const SEED_LENGTHS = [12, 15, 18, 21, 24];
+const ETH_DEFAULT_PATH = "m/44'/60'/0'/0/0";
+// const ETH_DEFAULT_PATH_2 = `/m/44'/60'/0'/0/0`;
+// console.log("ETH_DEFAULT_PATH",ETH_DEFAULT_PATH,ETH_DEFAULT_PATH_2)
 
 // a global registry to use internally
 const registry = new TypeRegistry();
@@ -296,11 +299,13 @@ export default class Extension {
     }
   }
 
-  private seedCreate ({ length = SEED_DEFAULT_LENGTH, type }: RequestSeedCreate): ResponseSeedCreate {
+  private seedCreate ({ length = SEED_DEFAULT_LENGTH, type , customEthDerivationPath=ETH_DEFAULT_PATH}: RequestSeedCreate): ResponseSeedCreate {
     let seed = mnemonicGenerate(length);
-
+    console.log("SEEDCREATE ",type)
     if (type === 'ethereum') {
-      seed += '/m/44\'/60\'/0\'/0/0';
+      console.log(seed, customEthDerivationPath)
+      seed =`${seed}/${customEthDerivationPath}` //customEthDerivationPath;
+      console.log('CREATE SEED ',seed)
     }
 
     return {

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -299,13 +299,15 @@ export default class Extension {
     }
   }
 
-  private seedCreate ({ length = SEED_DEFAULT_LENGTH, type , customEthDerivationPath=ETH_DEFAULT_PATH}: RequestSeedCreate): ResponseSeedCreate {
+  private seedCreate ({ length = SEED_DEFAULT_LENGTH, type, customEthDerivationPath = ETH_DEFAULT_PATH }: RequestSeedCreate): ResponseSeedCreate {
     let seed = mnemonicGenerate(length);
-    console.log("SEEDCREATE ",type)
+
+    console.log('SEEDCREATE ', type);
+
     if (type === 'ethereum') {
-      console.log(seed, customEthDerivationPath)
-      seed =`${seed}/${customEthDerivationPath}` //customEthDerivationPath;
-      console.log('CREATE SEED ',seed)
+      console.log(seed, customEthDerivationPath);
+      seed = `${seed}/${customEthDerivationPath}`; // customEthDerivationPath;
+      console.log('CREATE SEED ', seed);
     }
 
     return {

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -298,8 +298,9 @@ export default class Extension {
 
   private seedCreate ({ length = SEED_DEFAULT_LENGTH, type }: RequestSeedCreate): ResponseSeedCreate {
     let seed = mnemonicGenerate(length);
-    if (type==="ethereum"){
-      seed+=`/m/44'/60'/0'/0/0`
+
+    if (type === 'ethereum') {
+      seed += '/m/44\'/60\'/0\'/0/0';
     }
 
     return {

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -297,6 +297,7 @@ export type RequestSigningSubscribe = null;
 export interface RequestSeedCreate {
   length?: SeedLengths;
   type?: KeypairType;
+  customEthDerivationPath?:string;
 }
 
 export interface RequestSeedValidate {

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -297,7 +297,7 @@ export type RequestSigningSubscribe = null;
 export interface RequestSeedCreate {
   length?: SeedLengths;
   type?: KeypairType;
-  customEthDerivationPath?:string;
+  customEthDerivationPath?: string;
 }
 
 export interface RequestSeedValidate {

--- a/packages/extension-ui/src/Popup/Accounts/Account.test.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.test.tsx
@@ -18,7 +18,7 @@ import Account from './Account';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
 configure({ adapter: new Adapter() });
 
-jest.spyOn(messaging, 'getAllMetatdata').mockResolvedValue([]);
+jest.spyOn(messaging, 'getAllMetadata').mockResolvedValue([]);
 
 describe('Account component', () => {
   let wrapper: ReactWrapper;

--- a/packages/extension-ui/src/Popup/CreateAccount/CreateAccount.test.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/CreateAccount.test.tsx
@@ -110,3 +110,4 @@ describe('Create Account', () => {
     });
   });
 });
+// TODO add ethereum/moonbeam test

--- a/packages/extension-ui/src/Popup/CreateAccount/CreateEthDerivationPath.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/CreateEthDerivationPath.tsx
@@ -1,0 +1,108 @@
+// Copyright 2017-2021 @polkadot/app-accounts authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import useTranslation from '@polkadot/extension-ui/hooks/useTranslation';
+import BN from 'bn.js';
+import React, { ReactNode, useEffect, useState } from 'react';
+
+import {InputWithLabel, Dropdown, Checkbox } from '../../components';
+
+// import { useToggle } from '@polkadot/react-hooks';
+
+// import { useTranslation } from '../translate';
+// import { DeriveValidationOutput } from '../types';
+
+interface Props {
+  className?: string;
+  onChange: (string: string) => void;
+  // seedType: string;
+  derivePath: string;
+  //deriveValidation: DeriveValidationOutput | undefined;
+  // seed: string;
+}
+
+export const ETH_DEFAULT_PATH = "m/44'/60'/0'/0/0";
+
+function CreateEthDerivationPath ({ className,
+  derivePath,
+  // deriveValidation,
+  onChange,
+  // seedType 
+}: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const [addIndex, setAddIndex] = useState(0);
+  const [customIndex, setCustomIndex] = useState(new BN(0));
+  const [addressList] = useState<{ key: number; text: ReactNode; value: number; }[]>(new Array(10).fill(0).map((_, i) => ({
+    key: i,
+    text: t('Address index {{index}}', {
+      replace: { index: i }
+    }),
+    value: i
+  })));
+  const [useCustomPath, setUseCustomPath] =  useState(false);
+  const [useCustomIndex, setUseCustomIndex] = useState(false);
+
+  // const errorIndex = useRef<Record<string, string>>({
+  //   INVALID_DERIVATION_PATH: t<string>('This is an invalid derivation path.'),
+  //   PASSWORD_IGNORED: t<string>('Password are ignored for hex seed'),
+  //   SOFT_NOT_ALLOWED: t<string>('Soft derivation paths are not allowed on ed25519'),
+  //   WARNING_SLASH_PASSWORD: t<string>('Your password contains at least one "/" character. Disregard this warning if it is intended.')
+  // });
+  function setCustomIndexText(inp:string){
+    setCustomIndex(new BN(inp))
+  }
+
+  useEffect((): void => {
+    onChange(`m/44'/60'/0'/0/${useCustomIndex ? Number(customIndex) : addIndex}`);
+  }, [customIndex, onChange, useCustomIndex, addIndex]);
+
+  return (
+          <>
+            <div className='saveToggle'>
+              <Checkbox
+                    checked={useCustomIndex}
+                    label={t<string>('Use custom address index')}
+                    onChange={setUseCustomIndex}
+                />
+            </div>
+            {useCustomIndex
+              ? (
+                <InputWithLabel
+                    label={t<string>('Custom index')}
+                    onChange={setCustomIndexText}
+                    type='text'
+                    className={className}
+                />
+              )
+              : (
+                <Dropdown
+                className={'derivation-path'}
+                label={t<string>('address index')}
+                onChange={setAddIndex}
+                options={addressList}
+                value={addIndex}
+              />
+              )}
+            <div className='saveToggle'>
+              <Checkbox
+                    checked={useCustomPath}
+                    label={t<string>('Use custom derivation index')}
+                    onChange={setUseCustomPath}
+                />
+            </div>
+            {useCustomPath
+              ? (
+                <InputWithLabel
+                    label={t<string>('secret derivation path')}
+                    onChange={onChange}
+                    type='text'
+                    value={derivePath}
+                    className={className}
+                />
+              )
+              : null}
+          </>
+  );
+}
+
+export default React.memo(CreateEthDerivationPath);

--- a/packages/extension-ui/src/Popup/CreateAccount/CreateEthDerivationPath.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/CreateEthDerivationPath.tsx
@@ -1,11 +1,12 @@
 // Copyright 2017-2021 @polkadot/app-accounts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import useTranslation from '@polkadot/extension-ui/hooks/useTranslation';
 import BN from 'bn.js';
 import React, { ReactNode, useEffect, useState } from 'react';
 
-import {InputWithLabel, Dropdown, Checkbox } from '../../components';
+import useTranslation from '@polkadot/extension-ui/hooks/useTranslation';
+
+import { Checkbox, Dropdown, InputWithLabel } from '../../components';
 
 // import { useToggle } from '@polkadot/react-hooks';
 
@@ -17,7 +18,7 @@ interface Props {
   onChange: (string: string) => void;
   // seedType: string;
   derivePath: string;
-  //deriveValidation: DeriveValidationOutput | undefined;
+  // deriveValidation: DeriveValidationOutput | undefined;
   // seed: string;
 }
 
@@ -26,8 +27,8 @@ export const ETH_DEFAULT_PATH = "m/44'/60'/0'/0/0";
 function CreateEthDerivationPath ({ className,
   derivePath,
   // deriveValidation,
-  onChange,
-  // seedType 
+  onChange
+  // seedType
 }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [addIndex, setAddIndex] = useState(0);
@@ -39,7 +40,7 @@ function CreateEthDerivationPath ({ className,
     }),
     value: i
   })));
-  const [useCustomPath, setUseCustomPath] =  useState(false);
+  const [useCustomPath, setUseCustomPath] = useState(false);
   const [useCustomIndex, setUseCustomIndex] = useState(false);
 
   // const errorIndex = useRef<Record<string, string>>({
@@ -48,8 +49,8 @@ function CreateEthDerivationPath ({ className,
   //   SOFT_NOT_ALLOWED: t<string>('Soft derivation paths are not allowed on ed25519'),
   //   WARNING_SLASH_PASSWORD: t<string>('Your password contains at least one "/" character. Disregard this warning if it is intended.')
   // });
-  function setCustomIndexText(inp:string){
-    setCustomIndex(new BN(inp))
+  function setCustomIndexText (inp: string) {
+    setCustomIndex(new BN(inp));
   }
 
   useEffect((): void => {
@@ -57,51 +58,51 @@ function CreateEthDerivationPath ({ className,
   }, [customIndex, onChange, useCustomIndex, addIndex]);
 
   return (
-          <>
-            <div className='saveToggle'>
-              <Checkbox
-                    checked={useCustomIndex}
-                    label={t<string>('Use custom address index')}
-                    onChange={setUseCustomIndex}
-                />
-            </div>
-            {useCustomIndex
-              ? (
-                <InputWithLabel
-                    label={t<string>('Custom index')}
-                    onChange={setCustomIndexText}
-                    type='text'
-                    className={className}
-                />
-              )
-              : (
-                <Dropdown
-                className={'derivation-path'}
-                label={t<string>('address index')}
-                onChange={setAddIndex}
-                options={addressList}
-                value={addIndex}
-              />
-              )}
-            <div className='saveToggle'>
-              <Checkbox
-                    checked={useCustomPath}
-                    label={t<string>('Use custom derivation index')}
-                    onChange={setUseCustomPath}
-                />
-            </div>
-            {useCustomPath
-              ? (
-                <InputWithLabel
-                    label={t<string>('secret derivation path')}
-                    onChange={onChange}
-                    type='text'
-                    value={derivePath}
-                    className={className}
-                />
-              )
-              : null}
-          </>
+    <>
+      <div className='saveToggle'>
+        <Checkbox
+          checked={useCustomIndex}
+          label={t<string>('Use custom address index')}
+          onChange={setUseCustomIndex}
+        />
+      </div>
+      {useCustomIndex
+        ? (
+          <InputWithLabel
+            className={className}
+            label={t<string>('Custom index')}
+            onChange={setCustomIndexText}
+            type='text'
+          />
+        )
+        : (
+          <Dropdown
+            className={'derivation-path'}
+            label={t<string>('address index')}
+            onChange={setAddIndex}
+            options={addressList}
+            value={addIndex}
+          />
+        )}
+      <div className='saveToggle'>
+        <Checkbox
+          checked={useCustomPath}
+          label={t<string>('Use custom derivation index')}
+          onChange={setUseCustomPath}
+        />
+      </div>
+      {useCustomPath
+        ? (
+          <InputWithLabel
+            className={className}
+            label={t<string>('secret derivation path')}
+            onChange={onChange}
+            type='text'
+            value={derivePath}
+          />
+        )
+        : null}
+    </>
   );
 }
 

--- a/packages/extension-ui/src/Popup/CreateAccount/index.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/index.tsx
@@ -17,6 +17,8 @@ interface Props {
   className?: string;
 }
 
+const ETHEREUM_CHAIN_NAMES = ['Moonbase Alpha', 'Moonriver'];
+
 function CreateAccount ({ className }: Props): React.ReactElement {
   const { t } = useTranslation();
   const onAction = useContext(ActionContext);
@@ -59,7 +61,7 @@ function CreateAccount ({ className }: Props): React.ReactElement {
       return newGenesisHash === value;
     });
 
-    if (chain?.text === 'Moonbase Alpha') { // TODO: use list
+    if (chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text)) {
       setType('ethereum');
     }
 

--- a/packages/extension-ui/src/Popup/CreateAccount/index.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/index.tsx
@@ -17,7 +17,7 @@ interface Props {
   className?: string;
 }
 
-const ETHEREUM_CHAIN_NAMES = ['Moonbase Alpha', 'Moonriver'];
+const ETHEREUM_CHAIN_NAMES = ['Moonbase Alpha','Moonriver'];
 
 function CreateAccount ({ className }: Props): React.ReactElement {
   const { t } = useTranslation();
@@ -60,8 +60,7 @@ function CreateAccount ({ className }: Props): React.ReactElement {
     const chain = options.find(({ value }) => {
       return newGenesisHash === value;
     });
-
-    if (chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text)) {
+    if ( chain?.chainType==="ethereum"||chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text)) {
       setType('ethereum');
     }
 

--- a/packages/extension-ui/src/Popup/CreateAccount/index.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/index.tsx
@@ -19,7 +19,6 @@ interface Props {
 }
 
 const ETHEREUM_CHAIN_NAMES = ['Moonbase Alpha', 'Moonriver'];
-console.log('669')
 function CreateAccount ({ className }: Props): React.ReactElement {
   const { t } = useTranslation();
   const onAction = useContext(ActionContext);
@@ -46,7 +45,6 @@ function CreateAccount ({ className }: Props): React.ReactElement {
       if (name && password && account) {
         setIsBusy(true);
         console.log("account.seed",account.seed)
-        // const suri=type==="ethereum"?account.seed+ethDerivePath:account.seed
         createAccountSuri(name, password, account.seed, type, genesisHash)
           .then(() => onAction('/'))
           .catch((error: Error): void => {
@@ -68,10 +66,6 @@ function CreateAccount ({ className }: Props): React.ReactElement {
     });
 
     // if chain has chain type ethereum or is in nbackup eth list, set type to eth
-    console.log('opt1',(chain?.chainType === 'ethereum' || (chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text))))
-    console.log('opt2',type==="ethereum" )
-    const currentType=type
-    console.log('type ',currentType)
     if (chain?.chainType === 'ethereum' || (chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text))) {
       setType('ethereum');
       // if type was set to type but new chain isnt, revert to sr25519
@@ -82,6 +76,7 @@ function CreateAccount ({ className }: Props): React.ReactElement {
     setGenesis(newGenesisHash);
   }, [options, type]);
 
+              //TODO remove derivation from mnemonic
   return (
     <>
       <HeaderWithSteps

--- a/packages/extension-ui/src/Popup/CreateAccount/index.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/index.tsx
@@ -17,7 +17,7 @@ interface Props {
   className?: string;
 }
 
-const ETHEREUM_CHAIN_NAMES = ['Moonbase Alpha','Moonriver'];
+const ETHEREUM_CHAIN_NAMES = ['Moonbase Alpha', 'Moonriver'];
 
 function CreateAccount ({ className }: Props): React.ReactElement {
   const { t } = useTranslation();
@@ -56,11 +56,12 @@ function CreateAccount ({ className }: Props): React.ReactElement {
   const _onPreviousStep = useCallback(() => setStep((step) => step - 1), []);
 
   const _onChangeNetwork = useCallback((newGenesisHash: string) => {
-    console.log("newGenesisHash",newGenesisHash)
+    console.log('newGenesisHash', newGenesisHash);
     const chain = options.find(({ value }) => {
       return newGenesisHash === value;
     });
-    if ( chain?.chainType==="ethereum"||chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text)) {
+
+    if (chain?.chainType === 'ethereum' || (chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text))) {
       setType('ethereum');
     }
 
@@ -95,17 +96,17 @@ function CreateAccount ({ className }: Props): React.ReactElement {
                 onNextStep={_onNextStep}
                 seed={account.seed}
               />
-              </>
+            </>
             )
             : (
-              
-                <AccountNamePasswordCreation
-                  buttonLabel={t<string>('Add the account with the generated seed')}
-                  isBusy={isBusy}
-                  onBackClick={_onPreviousStep}
-                  onCreate={_onCreate}
-                  onNameChange={setName}
-                />
+
+              <AccountNamePasswordCreation
+                buttonLabel={t<string>('Add the account with the generated seed')}
+                isBusy={isBusy}
+                onBackClick={_onPreviousStep}
+                onCreate={_onCreate}
+                onNameChange={setName}
+              />
             )
         )}
       </Loading>

--- a/packages/extension-ui/src/Popup/CreateAccount/index.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/index.tsx
@@ -19,6 +19,7 @@ interface Props {
 }
 
 const ETHEREUM_CHAIN_NAMES = ['Moonbase Alpha', 'Moonriver'];
+
 function CreateAccount ({ className }: Props): React.ReactElement {
   const { t } = useTranslation();
   const onAction = useContext(ActionContext);
@@ -32,19 +33,19 @@ function CreateAccount ({ className }: Props): React.ReactElement {
   const [genesisHash, setGenesis] = useState('');
 
   useEffect((): void => {
-    console.log("TYPE",type)
-    console.log("ethDerivePath",ethDerivePath)
-    createSeed(undefined, type,ethDerivePath)
+    console.log('TYPE', type);
+    console.log('ethDerivePath', ethDerivePath);
+    createSeed(undefined, type, ethDerivePath)
       .then(setAccount)
       .catch((error: Error) => console.error(error));
-  }, [type,ethDerivePath]);
+  }, [type, ethDerivePath]);
 
   const _onCreate = useCallback(
     (name: string, password: string): void => {
       // this should always be the case
       if (name && password && account) {
         setIsBusy(true);
-        console.log("account.seed",account.seed)
+        console.log('account.seed', account.seed);
         createAccountSuri(name, password, account.seed, type, genesisHash)
           .then(() => onAction('/'))
           .catch((error: Error): void => {
@@ -69,14 +70,14 @@ function CreateAccount ({ className }: Props): React.ReactElement {
     if (chain?.chainType === 'ethereum' || (chain && ETHEREUM_CHAIN_NAMES.includes(chain?.text))) {
       setType('ethereum');
       // if type was set to type but new chain isnt, revert to sr25519
-    } else if (type==="ethereum"){
-      setType(DEFAULT_TYPE)
-    } 
+    } else if (type === 'ethereum') {
+      setType(DEFAULT_TYPE);
+    }
 
     setGenesis(newGenesisHash);
   }, [options, type]);
 
-              //TODO remove derivation from mnemonic
+  // TODO remove derivation from mnemonic
   return (
     <>
       <HeaderWithSteps
@@ -101,7 +102,12 @@ function CreateAccount ({ className }: Props): React.ReactElement {
                 options={options}
                 value={genesisHash}
               />
-              {type==="ethereum"?<CreateEthDerivationPath derivePath={ethDerivePath} onChange={setEthDerivePath}  />:null}
+              {type === 'ethereum'
+                ? <CreateEthDerivationPath
+                  derivePath={ethDerivePath}
+                  onChange={setEthDerivePath}
+                />
+                : null}
               <Mnemonic
                 onNextStep={_onNextStep}
                 seed={account.seed}

--- a/packages/extension-ui/src/Popup/CreateAccount/index.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/index.tsx
@@ -41,7 +41,6 @@ function CreateAccount ({ className }: Props): React.ReactElement {
       // this should always be the case
       if (name && password && account) {
         setIsBusy(true);
-
         createAccountSuri(name, password, account.seed, type, genesisHash)
           .then(() => onAction('/'))
           .catch((error: Error): void => {
@@ -57,6 +56,7 @@ function CreateAccount ({ className }: Props): React.ReactElement {
   const _onPreviousStep = useCallback(() => setStep((step) => step - 1), []);
 
   const _onChangeNetwork = useCallback((newGenesisHash: string) => {
+    console.log("newGenesisHash",newGenesisHash)
     const chain = options.find(({ value }) => {
       return newGenesisHash === value;
     });
@@ -83,21 +83,22 @@ function CreateAccount ({ className }: Props): React.ReactElement {
         </div>
         {account && (
           step === 1
-            ? (
+            ? (<>
+              <Dropdown
+                className={className}
+                label={t<string>('Network')}
+                onChange={_onChangeNetwork}
+                options={options}
+                value={genesisHash}
+              />
               <Mnemonic
                 onNextStep={_onNextStep}
                 seed={account.seed}
               />
+              </>
             )
             : (
-              <>
-                <Dropdown
-                  className={className}
-                  label={t<string>('Network')}
-                  onChange={_onChangeNetwork}
-                  options={options}
-                  value={genesisHash}
-                />
+              
                 <AccountNamePasswordCreation
                   buttonLabel={t<string>('Add the account with the generated seed')}
                   isBusy={isBusy}
@@ -105,7 +106,6 @@ function CreateAccount ({ className }: Props): React.ReactElement {
                   onCreate={_onCreate}
                   onNameChange={setName}
                 />
-              </>
             )
         )}
       </Loading>

--- a/packages/extension-ui/src/Popup/ImportSeed/ImportSeed.test.tsx
+++ b/packages/extension-ui/src/Popup/ImportSeed/ImportSeed.test.tsx
@@ -26,7 +26,7 @@ const account = {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
 configure({ adapter: new Adapter() });
 
-jest.spyOn(messaging, 'getAllMetatdata').mockResolvedValue([]);
+jest.spyOn(messaging, 'getAllMetadata').mockResolvedValue([]);
 
 const typeSeed = async (wrapper: ReactWrapper, value: string) => {
   wrapper.find('textarea').first().simulate('change', { target: { value } });

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -83,7 +83,7 @@ function recodeAddress (address: string, accounts: AccountWithChildren[], chain:
   // always allow the actual settings to override the display
   return {
     account,
-    formatted: encodeAddress(publicKey, prefix),
+    formatted: publicKey.length === 20 ? address : encodeAddress(publicKey, prefix), // for ethereum address, no need to encode
     genesisHash: account?.genesisHash,
     prefix,
     type: account?.type || DEFAULT_TYPE

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -118,6 +118,7 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
     const recoded = (chain?.definition.chainType === 'ethereum' || accountByAddress?.type === 'ethereum' || (!accountByAddress && givenType === 'ethereum'))
       ? { account: accountByAddress, formatted: address, type: 'ethereum' } as Recoded
       : recodeAddress(address, accounts, chain, settings);
+
     setRecoded(recoded || defaultRecoded);
   }, [accounts, address, chain, givenType, settings]);
 
@@ -140,10 +141,9 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
   // Note: ethereum typed blockchain dont have the right chain.icon yet
   const theme = (
     type === 'ethereum'
-        ? 'ethereum'
-        : 
-    chain?.icon
-      ? chain.icon
+      ? 'ethereum'
+      : chain?.icon
+        ? chain.icon
         : 'substrate'
   ) as IconTheme;
 

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -115,11 +115,9 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
     }
 
     const accountByAddress = findAccountByAddress(accounts, address);
-
     const recoded = (chain?.definition.chainType === 'ethereum' || accountByAddress?.type === 'ethereum' || (!accountByAddress && givenType === 'ethereum'))
       ? { account: accountByAddress, formatted: address, type: 'ethereum' } as Recoded
       : recodeAddress(address, accounts, chain, settings);
-
     setRecoded(recoded || defaultRecoded);
   }, [accounts, address, chain, givenType, settings]);
 
@@ -139,12 +137,14 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
     setShowActionsMenu(false);
   }, [toggleActions]);
 
+  // Note: ethereum typed blockchain dont have the right chain.icon yet
   const theme = (
+    type === 'ethereum'
+        ? 'ethereum'
+        : 
     chain?.icon
       ? chain.icon
-      : type === 'ethereum'
-        ? 'ethereum'
-        : 'polkadot'
+        : 'substrate'
   ) as IconTheme;
 
   const _onClick = useCallback((): void => setShowActionsMenu(!showActionsMenu), [showActionsMenu]);

--- a/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
+++ b/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
@@ -3,14 +3,14 @@
 
 import { useEffect, useMemo, useState } from 'react';
 
-import { getAllMetatdata } from '../messaging';
+import { getAllMetadata } from '../messaging';
 import chains from '../util/chains';
 import useTranslation from './useTranslation';
 
 interface Option {
   text: string;
   value: string;
-  chainType:"substrate" | "ethereum" |undefined
+  chainType: 'substrate' | 'ethereum' |undefined
 }
 
 const RELAY_CHAIN = 'Relay Chain';
@@ -20,9 +20,8 @@ export default function (): Option[] {
   const [metadataChains, setMetadatachains] = useState<Option[]>([]);
 
   useEffect(() => {
-    getAllMetatdata().then((metadataDefs) => {
-      console.log("metadataDefs",metadataDefs)
-      const res = metadataDefs.map((metadata) => ({ text: metadata.chain, value: metadata.genesisHash, chainType:metadata.chainType||'substrate' }));
+    getAllMetadata().then((metadataDefs) => {
+      const res = metadataDefs.map((metadata) => ({ chainType: metadata.chainType || 'substrate', text: metadata.chain, value: metadata.genesisHash }));
 
       setMetadatachains(res);
     }).catch(console.error);
@@ -30,21 +29,22 @@ export default function (): Option[] {
 
   const hashes = useMemo(() => [
     {
+      chainType: undefined,
       text: t('Allow use on any chain'),
-      value: '',
-      chainType:undefined
+      value: ''
     },
     // put the relay chains at the top
     ...chains.filter(({ chain }) => chain.includes(RELAY_CHAIN))
-      .map(({ chain, genesisHash,chainType }) => ({
+      .map(({ chain, chainType, genesisHash }) => ({
+        chainType,
         text: chain,
-        value: genesisHash,
-        chainType
+        value: genesisHash
       })),
-    ...chains.map(({ chain, genesisHash, chainType }) => ({
+    ...chains.map(({ chain, chainType, genesisHash }) => ({
+      chainType,
       text: chain,
-      value: genesisHash,
-      chainType
+      value: genesisHash
+
     }))
       // remove the relay chains, they are at the top already
       .filter(({ text }) => !text.includes(RELAY_CHAIN))

--- a/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
+++ b/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
@@ -10,6 +10,7 @@ import useTranslation from './useTranslation';
 interface Option {
   text: string;
   value: string;
+  chainType:"substrate" | "ethereum" |undefined
 }
 
 const RELAY_CHAIN = 'Relay Chain';
@@ -20,7 +21,8 @@ export default function (): Option[] {
 
   useEffect(() => {
     getAllMetatdata().then((metadataDefs) => {
-      const res = metadataDefs.map((metadata) => ({ text: metadata.chain, value: metadata.genesisHash }));
+      console.log("metadataDefs",metadataDefs)
+      const res = metadataDefs.map((metadata) => ({ text: metadata.chain, value: metadata.genesisHash, chainType:metadata.chainType||'substrate' }));
 
       setMetadatachains(res);
     }).catch(console.error);
@@ -29,17 +31,20 @@ export default function (): Option[] {
   const hashes = useMemo(() => [
     {
       text: t('Allow use on any chain'),
-      value: ''
+      value: '',
+      chainType:undefined
     },
     // put the relay chains at the top
     ...chains.filter(({ chain }) => chain.includes(RELAY_CHAIN))
-      .map(({ chain, genesisHash }) => ({
+      .map(({ chain, genesisHash,chainType }) => ({
         text: chain,
-        value: genesisHash
+        value: genesisHash,
+        chainType
       })),
-    ...chains.map(({ chain, genesisHash }) => ({
+    ...chains.map(({ chain, genesisHash, chainType }) => ({
       text: chain,
-      value: genesisHash
+      value: genesisHash,
+      chainType
     }))
       // remove the relay chains, they are at the top already
       .filter(({ text }) => !text.includes(RELAY_CHAIN))

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -135,7 +135,7 @@ export async function createSeed (length?: SeedLengths, type?: KeypairType): Pro
   return sendMessage('pri(seed.create)', { length, type });
 }
 
-export async function getAllMetatdata (): Promise<MetadataDef[]> {
+export async function getAllMetadata (): Promise<MetadataDef[]> {
   return sendMessage('pri(metadata.list)');
 }
 

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -131,8 +131,8 @@ export async function createAccountSuri (name: string, password: string, suri: s
   return sendMessage('pri(accounts.create.suri)', { genesisHash, name, password, suri, type });
 }
 
-export async function createSeed (length?: SeedLengths, type?: KeypairType): Promise<{ address: string; seed: string }> {
-  return sendMessage('pri(seed.create)', { length, type });
+export async function createSeed (length?: SeedLengths, type?: KeypairType, customEthDerivationPath?:string): Promise<{ address: string; seed: string }> {
+  return sendMessage('pri(seed.create)', { length, type, customEthDerivationPath });
 }
 
 export async function getAllMetadata (): Promise<MetadataDef[]> {

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -131,7 +131,7 @@ export async function createAccountSuri (name: string, password: string, suri: s
   return sendMessage('pri(accounts.create.suri)', { genesisHash, name, password, suri, type });
 }
 
-export async function createSeed (length?: SeedLengths, type?: KeypairType, customEthDerivationPath?:string): Promise<{ address: string; seed: string }> {
+export async function createSeed (length?: SeedLengths, type?: KeypairType, customEthDerivationPath?: string): Promise<{ address: string; seed: string }> {
   return sendMessage('pri(seed.create)', { length, type, customEthDerivationPath });
 }
 

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -159,5 +159,13 @@
   "All account": "",
   "password for encrypting all accounts": "",
   "I want to export all my accounts": "",
-  "Notifications": ""
+  "Notifications": "",
+  "This is an invalid derivation path.": "",
+  "Password are ignored for hex seed": "",
+  "Soft derivation paths are not allowed on ed25519": "",
+  "Your password contains at least one \"/\" character. Disregard this warning if it is intended.": "",
+  "Use custom address index": "",
+  "Custom index": "",
+  "Use custom derivation index": "",
+  "secret derivation path": ""
 }


### PR DESCRIPTION
Unfortunately, I forgot to add Moonriver, so the extension compatibility only works with Moonbase Alpha...
@jacogr let me know if you can think of a better place to store this list (it is not the same as `import { ethereumChains } from '@polkadot/apps-config';`, which is runtime specname whereas in the extension it is the chain name)