### PR TITLE
fix(authorize): long urls pushes the cta down

### DIFF
--- a/packages/extension-ui/src/Popup/Authorize/Request.tsx
+++ b/packages/extension-ui/src/Popup/Authorize/Request.tsx
@@ -108,6 +108,7 @@ export default styled(Request)(({ theme }: Props) => `
   .tab-url {
     color: ${theme.textColor};
     display: inline-block;
+    max-height: 10rem;
     max-width: 20rem;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
This PR fixes the issue where a long url breaks the Authorize popup window.
![Screen Shot 2022-02-18 at 4 52 05 pm](https://user-images.githubusercontent.com/3857045/154651785-1faaad1e-e426-4a8c-a84f-af7d7b556c8e.png)
<img width="560" alt="Screen Shot 2022-02-18 at 4 52 42 pm" src="https://user-images.githubusercontent.com/3857045/154651833-43c82f5c-6a83-471b-85d4-d261c1d310b7.png">
