### PR TITLE
Add option for selecting crypto type on import

### DIFF
--- a/packages/extension-ui/src/Popup/ImportSeed/SeedAndPath.tsx
+++ b/packages/extension-ui/src/Popup/ImportSeed/SeedAndPath.tsx
@@ -21,10 +21,17 @@ interface Props {
   className?: string;
   onNextStep: () => void;
   onAccountChange: (account: AccountInfo | null) => void;
+  onTypeChange: (type: KeypairType) => void;
   type: KeypairType;
 }
 
-function SeedAndPath ({ className, onAccountChange, onNextStep, type }: Props): React.ReactElement {
+const keypairTypes = ['ed25519', 'sr25519', 'ecdsa'];
+
+function isKeypairType (value: string): value is KeypairType {
+  return keypairTypes.includes(value);
+}
+
+function SeedAndPath ({ className, onAccountChange, onNextStep, onTypeChange, type }: Props): React.ReactElement {
   const { t } = useTranslation();
   const genesisOptions = useGenesisHashOptions();
   const [address, setAddress] = useState('');
@@ -33,6 +40,11 @@ function SeedAndPath ({ className, onAccountChange, onNextStep, type }: Props): 
   const [advanced, setAdvances] = useState(false);
   const [error, setError] = useState('');
   const [genesis, setGenesis] = useState('');
+
+  const keypairTypeOptions = keypairTypes.map((name: string) => ({
+    text: name,
+    value: name
+  }));
 
   useEffect(() => {
     // No need to validate an empty seed
@@ -66,6 +78,14 @@ function SeedAndPath ({ className, onAccountChange, onNextStep, type }: Props): 
   const _onToggleAdvanced = useCallback(() => {
     setAdvances(!advanced);
   }, [advanced]);
+
+  const _onTypeChange = (value: string) => {
+    if (isKeypairType(value)) {
+      onTypeChange(value);
+    } else {
+      setError('');
+    }
+  };
 
   return (
     <>
@@ -109,6 +129,15 @@ function SeedAndPath ({ className, onAccountChange, onNextStep, type }: Props): 
             label={t<string>('derivation path')}
             onChange={setPath}
             value={path || ''}
+          />
+        )}
+        { advanced && (
+          <Dropdown
+            className='cryptoTypeSelection'
+            label={t<string>('crypto type')}
+            onChange={_onTypeChange}
+            options={keypairTypeOptions}
+            value={type}
           />
         )}
         {!!error && !!seed && (

--- a/packages/extension-ui/src/Popup/ImportSeed/index.tsx
+++ b/packages/extension-ui/src/Popup/ImportSeed/index.tsx
@@ -83,6 +83,7 @@ function ImportSeed (): React.ReactElement {
           <SeedAndPath
             onAccountChange={setAccount}
             onNextStep={_onNextStep}
+            onTypeChange={setType}
             type={type}
           />
         )

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -161,5 +161,6 @@
   "I want to export all my accounts": "",
   "Notifications": "",
   "Search by name or network...": "",
-  "Message signing is not supported for hardware wallets.": ""
+  "Message signing is not supported for hardware wallets.": "",
+  "crypto type": ""
 }


### PR DESCRIPTION
This PR adds a dropdown to the "advanced" section of the "Import account" dialog that allows selecting the keypair's crypto type. It was already possible to import other keypair types by restoring from a JSON file, now it is possible to import other keypair types by seed.