### PR TITLE
Handle possible promise rejections/callback throws with logging

### DIFF
--- a/packages/extension-dapp/src/bundle.ts
+++ b/packages/extension-dapp/src/bundle.ts
@@ -165,8 +165,11 @@ export async function web3AccountsSubscribe (cb: (accounts: InjectedAccountWithM
       subscribe((result): void => {
         accounts[source] = result;
 
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        triggerUpdate();
+        try {
+          triggerUpdate()?.catch(console.error);
+        } catch (error) {
+          console.error(error);
+        }
       })
   );
 


### PR DESCRIPTION
As per [this comment](https://github.com/polkadot-js/extension/pull/1063#issuecomment-1127628581), we certainly didn't handle the rejections correctly. 

This is actually critically important since these error would come from external user-supplied code, i.e. the callback is passed in from the user and any failures shouldn't make our side of the fence break.