### PR TITLE
can not read the length of an undefined

### DIFF
--- a/packages/extension-ui/src/Popup/Accounts/index.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/index.tsx
@@ -43,7 +43,7 @@ function Accounts ({ className }: Props): React.ReactElement {
 
   return (
     <>
-      {(hierarchy.length === 0)
+      {(hierarchy?.length === 0)
         ? <AddAccount />
         : (
           <>


### PR DESCRIPTION
In some cases (when computer is busy or have many accounts), throw the error :' can not read the length of an undefined'
hence changed hierarchy.length ===> hierarchy?.length