### PR TITLE
fix(RemoveAuth): icon cursor & size

### DIFF
--- a/packages/extension-ui/src/components/RemoveAuth.tsx
+++ b/packages/extension-ui/src/components/RemoveAuth.tsx
@@ -13,7 +13,6 @@ function RemoveAuth (): React.ReactElement {
     <FontAwesomeIcon
       className='trashIcon'
       icon={faTrash}
-      size='sm'
     />
   );
 }
@@ -23,6 +22,7 @@ export default styled(RemoveAuth)(({ theme }: ThemeProps) => `
     cursor: pointer;
     color: ${theme.iconNeutralColor};
     margin-left: 8px;
+    vertical-align: middle;
 
     &.selected {
       color: ${theme.primaryColor};

--- a/packages/extension-ui/src/components/RemoveAuth.tsx
+++ b/packages/extension-ui/src/components/RemoveAuth.tsx
@@ -13,21 +13,14 @@ function RemoveAuth (): React.ReactElement {
     <FontAwesomeIcon
       className='trashIcon'
       icon={faTrash}
-      size='lg'
+      size='sm'
     />
   );
 }
 
 export default styled(RemoveAuth)(({ theme }: ThemeProps) => `
-  label {
-    position: relative;
-    display: inline-block;
-    width: 48px;
-    height: 24px;
-    margin: 8px;
-  }
-
   .trashIcon {
+    cursor: pointer;
     color: ${theme.iconNeutralColor};
     margin-left: 8px;
 


### PR DESCRIPTION
Hello, this PR fix removeAuth button UI, I've:
- align icon with text
- reduce icon size
- remove unused code
- show cursor

#### 🖼️  screenshot

**before**
<img width="560" alt="Capture d’écran 2022-06-10 à 10 11 44 AM" src="https://user-images.githubusercontent.com/9987732/173021627-5dda81b3-ac2b-433c-a06d-d371279ea262.png">

**after**
<img width="560" alt="Capture d’écran 2022-06-10 à 10 05 24 AM" src="https://user-images.githubusercontent.com/9987732/173021049-9a55939a-9ba5-439f-85cb-86eda5347767.png">

