### PR TITLE
Fix indeterminate state not reseting on account selection

### DIFF
--- a/packages/extension-ui/src/components/Checkbox.tsx
+++ b/packages/extension-ui/src/components/Checkbox.tsx
@@ -21,8 +21,8 @@ function Checkbox ({ checked, className, indeterminate, label, onChange, onClick
   const checkboxRef = React.useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (indeterminate && checkboxRef.current) {
-      checkboxRef.current.indeterminate = true;
+    if (checkboxRef.current) {
+      checkboxRef.current.indeterminate = !!indeterminate;
     }
   }, [indeterminate]);
 


### PR DESCRIPTION
I found a small bug with the indeterminate state, here is when it happened
:heavy_check_mark:  When selecting only some accounts -> checkbox is indeterminate
:heavy_multiplication_x: When manually deselecting all account -> checkbox is still indeterminate whereas it should be unchecked

After the fix:

https://user-images.githubusercontent.com/33178835/178993235-1c789439-0300-444f-8d94-d019023a9bae.mp4





