### PR TITLE
Fix ask again invisible in popup

### DIFF
--- a/packages/extension-ui/src/Popup/Authorize/Request.tsx
+++ b/packages/extension-ui/src/Popup/Authorize/Request.tsx
@@ -84,15 +84,16 @@ function Request ({ authId, className, isFirst, request: { origin }, url }: Prop
 export default styled(Request)`
   .acceptButton {
     width: 90%;
-    margin: 1rem auto 0;
+    margin: .5rem auto 0;
   }
 
   .rejectionButton {
-    margin: 8px 0 15px 0;
+    margin: 0 0 15px 0;
     text-decoration: underline;
 
     .closeLink {
       margin: auto;
+      padding: 0;
     }
   }
 `;


### PR DESCRIPTION
closes https://github.com/polkadot-js/extension/issues/1118

While I couldn't reproduce it in the initial popup, I could see the ask again hidden in the popup that appears when clicking on the extension icon. I bet that's what you meant, I missed this originally, sorry about that. I did some small adjustment to have it visible.

![image](https://user-images.githubusercontent.com/33178835/181212872-71315f01-50c8-4c2e-b6be-c6bd2cf63081.png)
