### PR TITLE
Add isEnabled call to get extension authorization status

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ window.injectedWeb3 = {
 
     // this call returns extension status that tells if extension is already authorized
     isEnabled (): Promise<boolean>,
+
     // semver for the package
     version: '0.1.0'
   }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As it stands, it does one thing: it _only_ manages accounts and allows the signi
 ![interface screenshots](docs/extension-overview.png)
 
 ## Documentation and examples
-Find out more about how to use the extension as a Dapp developper, cookbook, as well as answers to most frequent questions in the [Polkadot-js extension documentation](https://polkadot.js.org/docs/extension/)
+Find out more about how to use the extension as a Dapp developer, cookbook, as well as answers to most frequent questions in the [Polkadot-js extension documentation](https://polkadot.js.org/docs/extension/)
 
 ## Development version
 

--- a/README.md
+++ b/README.md
@@ -113,13 +113,15 @@ window.injectedWeb3 = {
   // this is the name for this extension, there could be multiples injected,
   // each with their own keys, here `polkadot-js` is for this extension
   'polkadot-js': {
-    // semver for the package
-    version: '0.1.0',
-
     // this is called to enable the injection, and returns an injected
     // object containing the accounts, signer and provider interfaces
     // (or it will reject if not authorized)
-    enable (originName: string): Promise<Injected>
+    enable (originName: string): Promise<Injected>,
+
+    // this call returns extension status that tells if extension is already authorized
+    isEnabled (): Promise<boolean>,
+    // semver for the package
+    version: '0.1.0'
   }
 }
 ```

--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -215,11 +215,14 @@ export default class Tabs {
       return this.redirectIfPhishing(url);
     }
 
-    if (type !== 'pub(authorize.tab)') {
+    if (type !== 'pub(authorize.tab)' && type !== 'pub(authorize.isEnabled)') {
       this.#state.ensureUrlAuthorized(url);
     }
 
     switch (type) {
+      case 'pub(authorize.isEnabled)':
+        return !!this.#state.authUrls[this.#state.stripUrl(url)];
+
       case 'pub(authorize.tab)':
         return this.authorize(url, request as RequestAuthorizeTab);
 

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -119,6 +119,7 @@ export interface RequestSignatures {
   'pub(accounts.list)': [RequestAccountList, InjectedAccount[]];
   'pub(accounts.subscribe)': [RequestAccountSubscribe, string, InjectedAccount[]];
   'pub(accounts.unsubscribe)': [RequestAccountUnsubscribe, boolean];
+  'pub(authorize.isEnabled)': [null, Promise<boolean>];
   'pub(authorize.tab)': [RequestAuthorizeTab, Promise<AuthResponse>];
   'pub(bytes.sign)': [SignerPayloadRaw, ResponseSigning];
   'pub(extrinsic.sign)': [SignerPayloadJSON, ResponseSigning];

--- a/packages/extension-base/src/page/index.ts
+++ b/packages/extension-base/src/page/index.ts
@@ -56,6 +56,12 @@ export async function enable (origin: string): Promise<Injected> {
   return new Injected(sendMessage);
 }
 
+export async function isEnabled (): Promise<boolean> {
+  const res = await sendMessage('pub(authorize.isEnabled)');
+
+  return res;
+}
+
 // redirect users if this page is considered as phishing, otherwise return false
 export async function redirectIfPhishing (): Promise<boolean> {
   const res = await sendMessage('pub(phishing.redirectIfDenied)');

--- a/packages/extension-compat-metamask/src/bundle.ts
+++ b/packages/extension-compat-metamask/src/bundle.ts
@@ -85,7 +85,7 @@ function injectMetaMaskWeb3 (win: Web3Window): void {
       };
     },
     isEnabled: async (): Promise<boolean> => {
-      return new Promise((resolve) => resolve(true));
+      return Promise.resolve(true);
     }, // TODO: stub for now
     version: '0' // TODO: win.ethereum.version
   };

--- a/packages/extension-compat-metamask/src/bundle.ts
+++ b/packages/extension-compat-metamask/src/bundle.ts
@@ -84,6 +84,9 @@ function injectMetaMaskWeb3 (win: Web3Window): void {
         }
       };
     },
+    isEnabled: async (): Promise<boolean> => {
+      return new Promise((resolve) => resolve(true));
+    }, // TODO: stub for now
     version: '0' // TODO: win.ethereum.version
   };
 }

--- a/packages/extension-inject/src/bundle.ts
+++ b/packages/extension-inject/src/bundle.ts
@@ -8,7 +8,7 @@ export { packageInfo } from './packageInfo';
 // It is recommended to always use the function below to shield the extension and dapp from
 // any future changes. The exposed interface will manage access between the 2 environments,
 // be it via window (current), postMessage (under consideration) or any other mechanism
-export function injectExtension (enable: (origin: string) => Promise<Injected>, { name, version }: InjectOptions): void {
+export function injectExtension (enable: (origin: string) => Promise<Injected>, isEnabled: () => Promise<boolean>, { name, version }: InjectOptions): void {
   // small helper with the typescript types, just cast window
   const windowInject = window as Window & InjectedWindow;
 
@@ -17,8 +17,8 @@ export function injectExtension (enable: (origin: string) => Promise<Injected>, 
 
   // add our enable function
   windowInject.injectedWeb3[name] = {
-    enable: (origin: string): Promise<Injected> =>
-      enable(origin),
+    enable,
+    isEnabled,
     version
   };
 }

--- a/packages/extension-inject/src/types.ts
+++ b/packages/extension-inject/src/types.ts
@@ -100,6 +100,7 @@ export interface Injected {
 
 export interface InjectedWindowProvider {
   enable: (origin: string) => Promise<Injected>;
+  isEnabled: () => Promise<boolean>;
   version: string;
 }
 

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -5,13 +5,13 @@ import type { RequestSignatures, TransportRequestMessage } from '@polkadot/exten
 import type { Message } from '@polkadot/extension-base/types';
 
 import { MESSAGE_ORIGIN_CONTENT } from '@polkadot/extension-base/defaults';
-import { enable, handleResponse, redirectIfPhishing } from '@polkadot/extension-base/page';
+import { enable, handleResponse, isEnabled, redirectIfPhishing } from '@polkadot/extension-base/page';
 import { injectExtension } from '@polkadot/extension-inject';
 
 import { packageInfo } from './packageInfo';
 
 function inject () {
-  injectExtension(enable, {
+  injectExtension(enable, isEnabled, {
     name: 'polkadot-js',
     version: packageInfo.version
   });


### PR DESCRIPTION
Currently there is no way of checking if extension is already authorized without calling a popup, so most dapp devs are holding status in localstorage or similar, which is a workaround and adds unnecessary code.

This PR solves that by adding isEnabled call to extension-inject, which can be used to get the extension status.

UseCase:
As a dapp dev I want to support multiple extensions, show their status connected/disconnected without calling .enable for all extensions at the same time and creating multiple popups, which is not a great UX.
I also don't want to be creating a custom solution to this problem and maintain it.