### PR TITLE
Adjust extension ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Ensure that `EXTENSION_PREFIX` is always set as part of `@polkadot/extension-base`
+
+
 ## 0.44.6 Aug 21, 2022
 
 - **Important** Not published to the stores, aligns with latest released packages.

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "lint": "polkadot-dev-run-lint",
     "postinstall": "polkadot-dev-yarn-only",
     "start": "yarn watch",
-    "test": "EXTENSION_PREFIX='polkadot-js' polkadot-dev-run-test --detectOpenHandles",
-    "test:one": "EXTENSION_PREFIX='polkadot-js' polkadot-dev-run-test --detectOpenHandles",
+    "test": "EXTENSION_PREFIX='test' polkadot-dev-run-test --detectOpenHandles",
+    "test:one": "EXTENSION_PREFIX='test' polkadot-dev-run-test --detectOpenHandles",
     "watch": "cd packages/extension && yarn polkadot-exec-webpack --config webpack.watch.cjs --mode development --watch"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "lint": "polkadot-dev-run-lint",
     "postinstall": "polkadot-dev-yarn-only",
     "start": "yarn watch",
-    "test": "polkadot-dev-run-test --detectOpenHandles",
-    "test:one": "polkadot-dev-run-test --detectOpenHandles",
+    "test": "EXTENSION_PREFIX='polkadot-js' polkadot-dev-run-test --detectOpenHandles",
+    "test:one": "EXTENSION_PREFIX='polkadot-js' polkadot-dev-run-test --detectOpenHandles",
     "watch": "cd packages/extension && yarn polkadot-exec-webpack --config webpack.watch.cjs --mode development --watch"
   },
   "devDependencies": {

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -5,7 +5,7 @@
 const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX || '';
 
 if (!EXTENSION_PREFIX) {
-  console.error('CRITICAL: The extension does not define an own EXTENSION_PREFIX environment variable as part of the build, this is required to ensure that messages are not shared between extensions. Failure to do so will yield messages sent to multiple extensions.');
+  throw new Error('CRITICAL: The extension does not define an own EXTENSION_PREFIX environment variable as part of the build, this is required to ensure that messages are not shared between extensions. Failure to do so will yield messages sent to multiple extensions.');
 }
 
 const PORT_PREFIX = `${EXTENSION_PREFIX || 'unknown'}-${process.env.PORT_PREFIX || 'unknown'}`;

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -1,13 +1,24 @@
 // Copyright 2019-2022 @polkadot/extension-base authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// this _must_ be changed for each extension
+const SUPPLIED_EXTENSION_PREFIX = process.env.EXTENSION_PREFIX;
+
+if (!SUPPLIED_EXTENSION_PREFIX) {
+  throw new Error('The extension does not define an own EXTENSION_PREFIX as part of the build, this is required to ensure that messages are not shared between extensions');
+}
+
+const EXTENSION_PREFIX = SUPPLIED_EXTENSION_PREFIX === 'polkadot-js'
+  ? ''
+  : SUPPLIED_EXTENSION_PREFIX;
+const PORT_PREFIX = `${EXTENSION_PREFIX}${EXTENSION_PREFIX ? '-' : ''}${SUPPLIED_EXTENSION_PREFIX}-`;
+const PORT_CONTENT = `${PORT_PREFIX}content`;
+const PORT_EXTENSION = `${PORT_PREFIX}extension`;
+const MESSAGE_ORIGIN_PAGE = `${PORT_PREFIX}page`;
+const MESSAGE_ORIGIN_CONTENT = `${PORT_PREFIX}content`;
+
 const ALLOWED_PATH = ['/', '/account/import-ledger', '/account/restore-json'] as const;
 const PHISHING_PAGE_REDIRECT = '/phishing-page-detected';
-const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX as string || '';
-const PORT_CONTENT = `${EXTENSION_PREFIX}content`;
-const PORT_EXTENSION = `${EXTENSION_PREFIX}extension`;
-const MESSAGE_ORIGIN_PAGE = `${EXTENSION_PREFIX}page`;
-const MESSAGE_ORIGIN_CONTENT = `${EXTENSION_PREFIX}content`;
 const PASSWORD_EXPIRY_MIN = 15;
 const PASSWORD_EXPIRY_MS = PASSWORD_EXPIRY_MIN * 60 * 1000;
 
@@ -19,6 +30,7 @@ export {
   EXTENSION_PREFIX,
   PORT_CONTENT,
   PORT_EXTENSION,
+  PORT_PREFIX,
   MESSAGE_ORIGIN_PAGE,
   MESSAGE_ORIGIN_CONTENT
 };

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // this _must_ be changed for each extension
-const SUPPLIED_EXTENSION_PREFIX = process.env.EXTENSION_PREFIX;
+const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX;
 
-if (!SUPPLIED_EXTENSION_PREFIX) {
-  throw new Error('The extension does not define an own EXTENSION_PREFIX as part of the build, this is required to ensure that messages are not shared between extensions');
+if (!EXTENSION_PREFIX) {
+  throw new Error('The extension does not define an own EXTENSION_PREFIX environment variable as part of the build, this is required to ensure that messages are not shared between extensions');
 }
 
-const EXTENSION_PREFIX = SUPPLIED_EXTENSION_PREFIX === 'polkadot-js'
-  ? ''
-  : SUPPLIED_EXTENSION_PREFIX;
-const PORT_PREFIX = `${EXTENSION_PREFIX}${EXTENSION_PREFIX ? '-' : ''}${SUPPLIED_EXTENSION_PREFIX}-`;
+const PORT_PREFIX = `${EXTENSION_PREFIX}-`;
 const PORT_CONTENT = `${PORT_PREFIX}content`;
 const PORT_EXTENSION = `${PORT_PREFIX}extension`;
 const MESSAGE_ORIGIN_PAGE = `${PORT_PREFIX}page`;

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -4,7 +4,7 @@
 // this _must_ be changed for each extension
 const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX || '';
 
-if (!EXTENSION_PREFIX) {
+if (!EXTENSION_PREFIX && !process.env.PORT_PREFIX) {
   throw new Error('CRITICAL: The extension does not define an own EXTENSION_PREFIX environment variable as part of the build, this is required to ensure that messages are not shared between extensions. Failure to do so will yield messages sent to multiple extensions.');
 }
 

--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -2,22 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // this _must_ be changed for each extension
-const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX;
+const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX || '';
 
 if (!EXTENSION_PREFIX) {
-  throw new Error('The extension does not define an own EXTENSION_PREFIX environment variable as part of the build, this is required to ensure that messages are not shared between extensions');
+  console.error('CRITICAL: The extension does not define an own EXTENSION_PREFIX environment variable as part of the build, this is required to ensure that messages are not shared between extensions. Failure to do so will yield messages sent to multiple extensions.');
 }
 
-const PORT_PREFIX = `${EXTENSION_PREFIX}-`;
-const PORT_CONTENT = `${PORT_PREFIX}content`;
-const PORT_EXTENSION = `${PORT_PREFIX}extension`;
-const MESSAGE_ORIGIN_PAGE = `${PORT_PREFIX}page`;
-const MESSAGE_ORIGIN_CONTENT = `${PORT_PREFIX}content`;
+const PORT_PREFIX = `${EXTENSION_PREFIX || 'unknown'}-${process.env.PORT_PREFIX || 'unknown'}`;
+const PORT_CONTENT = `${PORT_PREFIX}-content`;
+const PORT_EXTENSION = `${PORT_PREFIX}-extension`;
+const MESSAGE_ORIGIN_PAGE = `${PORT_PREFIX}-page`;
+const MESSAGE_ORIGIN_CONTENT = `${PORT_PREFIX}-content`;
 
 const ALLOWED_PATH = ['/', '/account/import-ledger', '/account/restore-json'] as const;
 const PHISHING_PAGE_REDIRECT = '/phishing-page-detected';
 const PASSWORD_EXPIRY_MIN = 15;
 const PASSWORD_EXPIRY_MS = PASSWORD_EXPIRY_MIN * 60 * 1000;
+
+// console.log(`Extension is sending and receiving messages on ${PORT_PREFIX}-*`);
 
 export {
   ALLOWED_PATH,
@@ -27,7 +29,6 @@ export {
   EXTENSION_PREFIX,
   PORT_CONTENT,
   PORT_EXTENSION,
-  PORT_PREFIX,
   MESSAGE_ORIGIN_PAGE,
   MESSAGE_ORIGIN_CONTENT
 };

--- a/packages/extension-base/src/stores/Accounts.ts
+++ b/packages/extension-base/src/stores/Accounts.ts
@@ -8,7 +8,11 @@ import BaseStore from './Base';
 
 export default class AccountsStore extends BaseStore<KeyringJson> implements KeyringStore {
   constructor () {
-    super(EXTENSION_PREFIX !== 'polkadot{.js}' ? `${EXTENSION_PREFIX || 'unknown'}accounts` : null);
+    super(
+      EXTENSION_PREFIX && EXTENSION_PREFIX !== 'polkadot{.js}'
+        ? `${EXTENSION_PREFIX}accounts`
+        : null
+    );
   }
 
   public override set (key: string, value: KeyringJson, update?: () => void): void {

--- a/packages/extension-base/src/stores/Accounts.ts
+++ b/packages/extension-base/src/stores/Accounts.ts
@@ -8,7 +8,7 @@ import BaseStore from './Base';
 
 export default class AccountsStore extends BaseStore<KeyringJson> implements KeyringStore {
   constructor () {
-    super(EXTENSION_PREFIX ? `${EXTENSION_PREFIX}accounts` : null);
+    super(EXTENSION_PREFIX !== 'polkadot{.js}' ? `${EXTENSION_PREFIX || 'unknown'}accounts` : null);
   }
 
   public override set (key: string, value: KeyringJson, update?: () => void): void {

--- a/packages/extension-base/src/stores/Metadata.ts
+++ b/packages/extension-base/src/stores/Metadata.ts
@@ -8,6 +8,6 @@ import BaseStore from './Base';
 
 export default class MetadataStore extends BaseStore<MetadataDef> {
   constructor () {
-    super(`${EXTENSION_PREFIX}metadata`);
+    super(`${EXTENSION_PREFIX !== 'polkadot{.js}' ? (EXTENSION_PREFIX || 'unknown') : ''}metadata`);
   }
 }

--- a/packages/extension-base/src/stores/Metadata.ts
+++ b/packages/extension-base/src/stores/Metadata.ts
@@ -8,6 +8,10 @@ import BaseStore from './Base';
 
 export default class MetadataStore extends BaseStore<MetadataDef> {
   constructor () {
-    super(`${EXTENSION_PREFIX !== 'polkadot{.js}' ? (EXTENSION_PREFIX || 'unknown') : ''}metadata`);
+    super(
+      EXTENSION_PREFIX && EXTENSION_PREFIX !== 'polkadot{.js}'
+        ? `${EXTENSION_PREFIX}metadata`
+        : 'metadata'
+    );
   }
 }

--- a/packages/extension-base/src/utils/getId.ts
+++ b/packages/extension-base/src/utils/getId.ts
@@ -6,5 +6,5 @@ import { EXTENSION_PREFIX } from '../defaults';
 let counter = 0;
 
 export function getId (): string {
-  return `${EXTENSION_PREFIX || 'unknown'}.${Date.now()}.${++counter}`;
+  return `${EXTENSION_PREFIX}.${Date.now()}.${++counter}`;
 }

--- a/packages/extension-base/src/utils/getId.ts
+++ b/packages/extension-base/src/utils/getId.ts
@@ -6,5 +6,5 @@ import { EXTENSION_PREFIX } from '../defaults';
 let counter = 0;
 
 export function getId (): string {
-  return `${EXTENSION_PREFIX}.${Date.now()}.${++counter}`;
+  return `${EXTENSION_PREFIX || 'unknown'}.${Date.now()}.${++counter}`;
 }

--- a/packages/extension/webpack.shared.cjs
+++ b/packages/extension/webpack.shared.cjs
@@ -72,7 +72,7 @@ module.exports = (entry, alias = {}) => ({
     }),
     new webpack.DefinePlugin({
       'process.env': {
-        EXTENSION_PREFIX: JSON.stringify(EXT_NAME),
+        EXTENSION_PREFIX: JSON.stringify(process.env.EXTENSION_PREFIX || EXT_NAME),
         NODE_ENV: JSON.stringify('production')
       }
     }),

--- a/packages/extension/webpack.shared.cjs
+++ b/packages/extension/webpack.shared.cjs
@@ -10,6 +10,8 @@ const ManifestPlugin = require('webpack-extension-manifest-plugin');
 const pkgJson = require('./package.json');
 const manifest = require('./manifest.json');
 
+const EXT_NAME = manifest.short_name.replace(/{/, '').replace(/}/, '').replace(/\./, '-');
+
 const packages = [
   'extension',
   'extension-base',
@@ -70,6 +72,7 @@ module.exports = (entry, alias = {}) => ({
     }),
     new webpack.DefinePlugin({
       'process.env': {
+        EXTENSION_PREFIX: JSON.stringify(EXT_NAME),
         NODE_ENV: JSON.stringify('production')
       }
     }),

--- a/packages/extension/webpack.shared.cjs
+++ b/packages/extension/webpack.shared.cjs
@@ -10,7 +10,7 @@ const ManifestPlugin = require('webpack-extension-manifest-plugin');
 const pkgJson = require('./package.json');
 const manifest = require('./manifest.json');
 
-const EXT_NAME = manifest.short_name.replace(/{/, '').replace(/}/, '').replace(/\./, '-');
+const EXT_NAME = manifest.short_name;
 
 const packages = [
   'extension',

--- a/packages/extension/webpack.shared.cjs
+++ b/packages/extension/webpack.shared.cjs
@@ -3,9 +3,10 @@
 
 const path = require('path');
 const webpack = require('webpack');
-
 const CopyPlugin = require('copy-webpack-plugin');
 const ManifestPlugin = require('webpack-extension-manifest-plugin');
+
+const { blake2AsHex } = require('@polkadot/util-crypto');
 
 const pkgJson = require('./package.json');
 const manifest = require('./manifest.json');
@@ -73,7 +74,8 @@ module.exports = (entry, alias = {}) => ({
     new webpack.DefinePlugin({
       'process.env': {
         EXTENSION_PREFIX: JSON.stringify(process.env.EXTENSION_PREFIX || EXT_NAME),
-        NODE_ENV: JSON.stringify('production')
+        NODE_ENV: JSON.stringify('production'),
+        PORT_PREFIX: JSON.stringify(blake2AsHex(JSON.stringify(manifest), 64))
       }
     }),
     new CopyPlugin({ patterns: [{ from: 'public' }] }),


### PR DESCRIPTION
Based on feedback, it would seem that there are some extensions out in the wild that does not add the `EXTENSION_PREFIX` environment variable and thus responds to all the same messages as the polkadot-js extension.

Change the build to include the ENV variable as part of the webpack build and by default on the extension so at least it does not respond to their messages. (If the variable is not supplied, it will try and retrieve it via the manifest). The base package will now throw and error if _not_ specified.

TL;DR Bugfix for mis-configured using the base packages, not sure how wide-spread this is.

cc @shawntabrizi 