### PR TITLE
Add link to accounts connected to the current tab in the header

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -6,7 +6,7 @@ import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta } from '@polkadot/
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
-import type { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MetadataRequest, RequestAccountBatchExport, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestBatchRestore, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, ResponseAccountExport, ResponseAccountsExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked, ResponseType, SigningRequest } from '../types';
+import type { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MetadataRequest, RequestAccountBatchExport, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestBatchRestore, RequestCurrentTabUrlUpdate, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, ResponseAccountExport, ResponseAccountsExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked, ResponseType, SigningRequest } from '../types';
 
 import { ALLOWED_PATH, PASSWORD_EXPIRY_MS } from '@polkadot/extension-base/defaults';
 import { TypeRegistry } from '@polkadot/types';
@@ -518,9 +518,17 @@ export default class Extension {
     return this.#state.deleteAuthRequest(requestId);
   }
 
+  private updateCurrentTabs ({ urls }: RequestCurrentTabUrlUpdate) {
+    this.#state.udateCurrentTabsUrl(urls);
+  }
+
+  private getConnectedTabUrls () {
+    return this.#state.getCurrentTabUrls();
+  }
+
   // Weird thought, the eslint override is not needed in Tabs
   // eslint-disable-next-line @typescript-eslint/require-await
-  public async handle<TMessageType extends MessageTypes> (id: string, type: TMessageType, request: RequestTypes[TMessageType], port: chrome.runtime.Port): Promise<ResponseType<TMessageType>> {
+  public async handle<TMessageType extends MessageTypes> (id: string, type: TMessageType, request: RequestTypes[TMessageType], port?: chrome.runtime.Port): Promise<ResponseType<TMessageType>> {
     switch (type) {
       case 'pri(authorize.approve)':
         return this.authorizeApprove(request as RequestAuthorizeApprove);
@@ -535,7 +543,7 @@ export default class Extension {
         return this.deleteAuthRequest(request as string);
 
       case 'pri(authorize.requests)':
-        return this.authorizeSubscribe(id, port);
+        return port && this.authorizeSubscribe(id, port);
 
       case 'pri(authorize.update)':
         return this.authorizeUpdate(request as RequestUpdateAuthorizedAccounts);
@@ -568,7 +576,7 @@ export default class Extension {
         return this.accountsShow(request as RequestAccountShow);
 
       case 'pri(accounts.subscribe)':
-        return this.accountsSubscribe(id, port);
+        return port && this.accountsSubscribe(id, port);
 
       case 'pri(accounts.tie)':
         return this.accountsTie(request as RequestAccountTie);
@@ -589,7 +597,13 @@ export default class Extension {
         return this.metadataReject(request as RequestMetadataReject);
 
       case 'pri(metadata.requests)':
-        return this.metadataSubscribe(id, port);
+        return port && this.metadataSubscribe(id, port);
+
+      case 'pri(activeTabsUrl.update)':
+        return this.updateCurrentTabs(request as RequestCurrentTabUrlUpdate);
+
+      case 'pri(connectedTabUrls.get)':
+        return this.getConnectedTabUrls();
 
       case 'pri(derivation.create)':
         return this.derivationCreate(request as RequestDeriveCreate);
@@ -628,7 +642,7 @@ export default class Extension {
         return this.signingIsLocked(request as RequestSigningIsLocked);
 
       case 'pri(signing.requests)':
-        return this.signingSubscribe(id, port);
+        return port && this.signingSubscribe(id, port);
 
       case 'pri(window.open)':
         return this.windowOpen(request as AllowedPath);

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -6,7 +6,7 @@ import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta } from '@polkadot/
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
-import type { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MetadataRequest, RequestAccountBatchExport, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestBatchRestore, RequestCurrentTabUrlUpdate, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, ResponseAccountExport, ResponseAccountsExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked, ResponseType, SigningRequest } from '../types';
+import type { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MetadataRequest, RequestAccountBatchExport, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestActiveTabsUrlUpdate, RequestAuthorizeApprove, RequestBatchRestore, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, ResponseAccountExport, ResponseAccountsExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked, ResponseType, SigningRequest } from '../types';
 
 import { ALLOWED_PATH, PASSWORD_EXPIRY_MS } from '@polkadot/extension-base/defaults';
 import { TypeRegistry } from '@polkadot/types';
@@ -518,12 +518,12 @@ export default class Extension {
     return this.#state.deleteAuthRequest(requestId);
   }
 
-  private updateCurrentTabs ({ urls }: RequestCurrentTabUrlUpdate) {
+  private updateCurrentTabs ({ urls }: RequestActiveTabsUrlUpdate) {
     this.#state.udateCurrentTabsUrl(urls);
   }
 
-  private getConnectedTabUrls () {
-    return this.#state.getCurrentTabUrls();
+  private getConnectedTabsUrl () {
+    return this.#state.getConnectedTabsUrl();
   }
 
   // Weird thought, the eslint override is not needed in Tabs
@@ -600,10 +600,10 @@ export default class Extension {
         return port && this.metadataSubscribe(id, port);
 
       case 'pri(activeTabsUrl.update)':
-        return this.updateCurrentTabs(request as RequestCurrentTabUrlUpdate);
+        return this.updateCurrentTabs(request as RequestActiveTabsUrlUpdate);
 
-      case 'pri(connectedTabUrls.get)':
-        return this.getConnectedTabUrls();
+      case 'pri(connectedTabsUrl.get)':
+        return this.getConnectedTabsUrl();
 
       case 'pri(derivation.create)':
         return this.derivationCreate(request as RequestDeriveCreate);

--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -153,7 +153,7 @@ export default class State {
 
   #windows: number[] = [];
 
-  #connectedTabUrls: string[] = [];
+  #connectedTabsUrl: string[] = [];
 
   public readonly authSubject: BehaviorSubject<AuthorizeRequest[]> = new BehaviorSubject<AuthorizeRequest[]>([]);
 
@@ -287,11 +287,11 @@ export default class State {
     })
       .filter((value) => !!value) as string[];
 
-    this.#connectedTabUrls = connectedTabs;
+    this.#connectedTabsUrl = connectedTabs;
   }
 
-  public getCurrentTabUrls () {
-    return this.#connectedTabUrls;
+  public getConnectedTabsUrl () {
+    return this.#connectedTabsUrl;
   }
 
   public deleteAuthRequest (requestId: string) {

--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -153,6 +153,8 @@ export default class State {
 
   #windows: number[] = [];
 
+  #connectedTabUrls: string[] = [];
+
   public readonly authSubject: BehaviorSubject<AuthorizeRequest[]> = new BehaviorSubject<AuthorizeRequest[]>([]);
 
   public readonly metaSubject: BehaviorSubject<MetadataRequest[]> = new BehaviorSubject<MetadataRequest[]>([]);
@@ -266,6 +268,31 @@ export default class State {
       }
     };
   };
+
+  public udateCurrentTabsUrl (urls: string[]) {
+    const connectedTabs = urls.map((url) => {
+      let strippedUrl = '';
+
+      // the assert in stripUrl may throw for new tabs with "chrome://newtab/"
+      try {
+        strippedUrl = this.stripUrl(url);
+      } catch (e) {
+        console.error(e);
+      }
+
+      // return the stripped url only if this website is known
+      return !!strippedUrl && this.authUrls[strippedUrl]
+        ? strippedUrl
+        : undefined;
+    })
+      .filter((value) => !!value) as string[];
+
+    this.#connectedTabUrls = connectedTabs;
+  }
+
+  public getCurrentTabUrls () {
+    return this.#connectedTabUrls;
+  }
 
   public deleteAuthRequest (requestId: string) {
     delete this.#authRequests[requestId];

--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -210,7 +210,7 @@ export default class Tabs {
     return false;
   }
 
-  public async handle<TMessageType extends MessageTypes> (id: string, type: TMessageType, request: RequestTypes[TMessageType], url: string, port: chrome.runtime.Port): Promise<ResponseTypes[keyof ResponseTypes]> {
+  public async handle<TMessageType extends MessageTypes> (id: string, type: TMessageType, request: RequestTypes[TMessageType], url: string, port?: chrome.runtime.Port): Promise<ResponseTypes[keyof ResponseTypes]> {
     if (type === 'pub(phishing.redirectIfDenied)') {
       return this.redirectIfPhishing(url);
     }
@@ -227,7 +227,7 @@ export default class Tabs {
         return this.accountsListAuthorized(url, request as RequestAccountList);
 
       case 'pub(accounts.subscribe)':
-        return this.accountsSubscribeAuthorized(url, id, port);
+        return port && this.accountsSubscribeAuthorized(url, id, port);
 
       case 'pub(accounts.unsubscribe)':
         return this.accountsUnsubscribe(url, request as RequestAccountUnsubscribe);
@@ -248,19 +248,19 @@ export default class Tabs {
         return this.rpcListProviders();
 
       case 'pub(rpc.send)':
-        return this.rpcSend(request as RequestRpcSend, port);
+        return port && this.rpcSend(request as RequestRpcSend, port);
 
       case 'pub(rpc.startProvider)':
-        return this.rpcStartProvider(request as string, port);
+        return port && this.rpcStartProvider(request as string, port);
 
       case 'pub(rpc.subscribe)':
-        return this.rpcSubscribe(request as RequestRpcSubscribe, id, port);
+        return port && this.rpcSubscribe(request as RequestRpcSubscribe, id, port);
 
       case 'pub(rpc.subscribeConnected)':
-        return this.rpcSubscribeConnected(request as null, id, port);
+        return port && this.rpcSubscribeConnected(request as null, id, port);
 
       case 'pub(rpc.unsubscribe)':
-        return this.rpcUnsubscribe(request as RequestRpcUnsubscribe, port);
+        return port && this.rpcUnsubscribe(request as RequestRpcUnsubscribe, port);
 
       default:
         throw new Error(`Unable to handle message of type ${type}`);

--- a/packages/extension-base/src/background/handlers/index.ts
+++ b/packages/extension-base/src/background/handlers/index.ts
@@ -14,9 +14,11 @@ const state = new State();
 const extension = new Extension(state);
 const tabs = new Tabs(state);
 
-export default function handler<TMessageType extends MessageTypes> ({ id, message, request }: TransportRequestMessage<TMessageType>, port: chrome.runtime.Port, extensionPortName = PORT_EXTENSION): void {
-  const isExtension = port.name === extensionPortName;
-  const sender = port.sender as chrome.runtime.MessageSender;
+export default function handler<TMessageType extends MessageTypes> ({ id, message, request }: TransportRequestMessage<TMessageType>, port?: chrome.runtime.Port, extensionPortName = PORT_EXTENSION): void {
+  const isExtension = !port || port?.name === extensionPortName;
+
+  const sender = port?.sender as chrome.runtime.MessageSender;
+
   const from = isExtension
     ? 'extension'
     : (sender.tab && sender.tab.url) || sender.url || '<unknown>';

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -75,7 +75,7 @@ export interface SigningRequest {
   url: string;
 }
 
-export type CurentTabUrlResponse = string[]
+export type ConnectedTabsUrlResponse = string[]
 
 // [MessageType]: [RequestType, ResponseType, SubscriptionMessageType?]
 export interface RequestSignatures {
@@ -99,8 +99,8 @@ export interface RequestSignatures {
   'pri(authorize.remove)': [string, ResponseAuthorizeList];
   'pri(authorize.delete.request)': [string, void];
   'pri(authorize.update)': [RequestUpdateAuthorizedAccounts, void];
-  'pri(activeTabsUrl.update)': [RequestCurrentTabUrlUpdate, void];
-  'pri(connectedTabUrls.get)': [null, CurentTabUrlResponse];
+  'pri(activeTabsUrl.update)': [RequestActiveTabsUrlUpdate, void];
+  'pri(connectedTabsUrl.get)': [null, ConnectedTabsUrlResponse];
   'pri(derivation.create)': [RequestDeriveCreate, boolean];
   'pri(derivation.validate)': [RequestDeriveValidate, ResponseDeriveValidate];
   'pri(json.restore)': [RequestJsonRestore, void];
@@ -266,7 +266,7 @@ export interface RequestAccountList {
 
 export type RequestAccountSubscribe = null;
 
-export interface RequestCurrentTabUrlUpdate {
+export interface RequestActiveTabsUrlUpdate {
   urls: string[];
 }
 

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -75,6 +75,8 @@ export interface SigningRequest {
   url: string;
 }
 
+export type CurentTabUrlResponse = string[]
+
 // [MessageType]: [RequestType, ResponseType, SubscriptionMessageType?]
 export interface RequestSignatures {
   // private/internal requests, i.e. from a popup
@@ -96,7 +98,9 @@ export interface RequestSignatures {
   'pri(authorize.requests)': [RequestAuthorizeSubscribe, boolean, AuthorizeRequest[]];
   'pri(authorize.remove)': [string, ResponseAuthorizeList];
   'pri(authorize.delete.request)': [string, void];
-  'pri(authorize.update)': [RequestUpdateAuthorizedAccounts, void]
+  'pri(authorize.update)': [RequestUpdateAuthorizedAccounts, void];
+  'pri(activeTabsUrl.update)': [RequestCurrentTabUrlUpdate, void];
+  'pri(connectedTabUrls.get)': [null, CurentTabUrlResponse];
   'pri(derivation.create)': [RequestDeriveCreate, boolean];
   'pri(derivation.validate)': [RequestDeriveValidate, ResponseDeriveValidate];
   'pri(json.restore)': [RequestJsonRestore, void];
@@ -261,6 +265,10 @@ export interface RequestAccountList {
 }
 
 export type RequestAccountSubscribe = null;
+
+export interface RequestCurrentTabUrlUpdate {
+  urls: string[];
+}
 
 export interface RequestAccountUnsubscribe {
   id: string;

--- a/packages/extension-ui/src/Popup/Accounts/index.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/index.tsx
@@ -50,6 +50,7 @@ function Accounts ({ className }: Props): React.ReactElement {
             <Header
               onFilter={_onFilter}
               showAdd
+              showConnectedAccounts
               showSearch
               showSettings
               text={t<string>('Accounts')}

--- a/packages/extension-ui/src/components/themes.ts
+++ b/packages/extension-ui/src/components/themes.ts
@@ -21,6 +21,7 @@ const darkTheme = {
   buttonBackgroundDangerHover: '#D93B3B',
   buttonBackgroundHover: '#ED9329',
   buttonTextColor: '#FFFFFF',
+  connectedDotColor: 'seagreen',
   errorBorderColor: '#7E3530',
   errorColor: '#E42F2F',
   fontFamily: 'Nunito, sans-serif',

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -1,7 +1,7 @@
 // Copyright 2019-2022 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithNullRequest, MessageTypesWithSubscriptions, MetadataRequest, RequestTypes, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSigningIsLocked, ResponseTypes, SeedLengths, SigningRequest, SubscriptionMessageTypes } from '@polkadot/extension-base/background/types';
+import type { AccountJson, AllowedPath, AuthorizeRequest, CurentTabUrlResponse, MessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithNullRequest, MessageTypesWithSubscriptions, MetadataRequest, RequestTypes, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSigningIsLocked, ResponseTypes, SeedLengths, SigningRequest, SubscriptionMessageTypes } from '@polkadot/extension-base/background/types';
 import type { Message } from '@polkadot/extension-base/types';
 import type { Chain } from '@polkadot/extension-chains/types';
 import type { KeyringPair$Json } from '@polkadot/keyring/types';
@@ -170,6 +170,10 @@ export async function getMetadata (genesisHash?: string | null, isPartial = fals
   }
 
   return null;
+}
+
+export async function getConnectedTabUrls (): Promise<CurentTabUrlResponse> {
+  return sendMessage('pri(connectedTabUrls.get)', null);
 }
 
 export async function rejectMetaRequest (id: string): Promise<boolean> {

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -1,7 +1,7 @@
 // Copyright 2019-2022 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountJson, AllowedPath, AuthorizeRequest, CurentTabUrlResponse, MessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithNullRequest, MessageTypesWithSubscriptions, MetadataRequest, RequestTypes, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSigningIsLocked, ResponseTypes, SeedLengths, SigningRequest, SubscriptionMessageTypes } from '@polkadot/extension-base/background/types';
+import type { AccountJson, AllowedPath, AuthorizeRequest, ConnectedTabsUrlResponse, MessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithNullRequest, MessageTypesWithSubscriptions, MetadataRequest, RequestTypes, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSigningIsLocked, ResponseTypes, SeedLengths, SigningRequest, SubscriptionMessageTypes } from '@polkadot/extension-base/background/types';
 import type { Message } from '@polkadot/extension-base/types';
 import type { Chain } from '@polkadot/extension-chains/types';
 import type { KeyringPair$Json } from '@polkadot/keyring/types';
@@ -172,8 +172,8 @@ export async function getMetadata (genesisHash?: string | null, isPartial = fals
   return null;
 }
 
-export async function getConnectedTabUrls (): Promise<CurentTabUrlResponse> {
-  return sendMessage('pri(connectedTabUrls.get)', null);
+export async function getConnectedTabsUrl (): Promise<ConnectedTabsUrlResponse> {
+  return sendMessage('pri(connectedTabsUrl.get)', null);
 }
 
 export async function rejectMetaRequest (id: string): Promise<boolean> {

--- a/packages/extension-ui/src/partials/Header.tsx
+++ b/packages/extension-ui/src/partials/Header.tsx
@@ -13,7 +13,7 @@ import InputFilter from '../components/InputFilter';
 import Link from '../components/Link';
 import useOutsideClick from '../hooks/useOutsideClick';
 import useTranslation from '../hooks/useTranslation';
-import { getConnectedTabUrls } from '../messaging';
+import { getConnectedTabsUrl } from '../messaging';
 import MenuAdd from './MenuAdd';
 import MenuSettings from './MenuSettings';
 
@@ -35,22 +35,22 @@ function Header ({ children, className = '', onFilter, showAdd, showBackArrow, s
   const [isSettingsOpen, setShowSettings] = useState(false);
   const [isSearchOpen, setShowSearch] = useState(false);
   const [filter, setFilter] = useState('');
-  const [connectedTabUrls, setConnectedTabUrls] = useState<string[]>([]);
+  const [connectedTabsUrl, setConnectedTabsUrl] = useState<string[]>([]);
   const { t } = useTranslation();
   const addIconRef = useRef(null);
   const addMenuRef = useRef(null);
   const setIconRef = useRef(null);
   const setMenuRef = useRef(null);
-  const isConnected = useMemo(() => connectedTabUrls.length >= 1
-    , [connectedTabUrls]);
+  const isConnected = useMemo(() => connectedTabsUrl.length >= 1
+    , [connectedTabsUrl]);
 
   useEffect(() => {
     if (!showConnectedAccounts) {
       return;
     }
 
-    getConnectedTabUrls()
-      .then((tabUrls) => setConnectedTabUrls(tabUrls))
+    getConnectedTabsUrl()
+      .then((tabsUrl) => setConnectedTabsUrl(tabsUrl))
       .catch(console.error);
   }, [showConnectedAccounts]);
 
@@ -122,7 +122,7 @@ function Header ({ children, className = '', onFilter, showAdd, showBackArrow, s
               <div className='connectedAccountsWrapper'>
                 <Link
                   className='connectedAccounts'
-                  to={connectedTabUrls.length === 1 ? `/url/manage/${connectedTabUrls[0]}` : '/auth-list'}
+                  to={connectedTabsUrl.length === 1 ? `/url/manage/${connectedTabsUrl[0]}` : '/auth-list'}
                 >
                   <span className='greenDot'>•</span>Connected
                 </Link>


### PR DESCRIPTION
- Issue: when a set of accounts are shared with a dapp, it is not easy for users to change the authorized accounts, it takes several clicks and it is error prone to search for the website manually. They'd have to go to setting > website management > find the current url > click on the number of accounts.
- Solution: when the current tab is a website that has been connected to in the past, show a "Connected" button in the header that will lead the the website management of the associated Dapp right away.

This issue has been reported to me by a user testing master, and I saw this issue coming back then here https://github.com/polkadot-js/extension/issues/1037#issuecomment-1081834987
I have tested this heavily with Brave and Firefox in light and dark mode.
The header is hidden when search is active to leave space.

Example with multi-windows browser


https://user-images.githubusercontent.com/33178835/188335115-761549a0-9fc3-480b-8b9f-eb7786d5a77e.mp4


