### PR TITLE
Use go-back instead of going to overview from the auth management

### DIFF
--- a/packages/extension-ui/src/Popup/AuthManagement/AccountManagement.tsx
+++ b/packages/extension-ui/src/Popup/AuthManagement/AccountManagement.tsx
@@ -5,9 +5,10 @@ import type { ThemeProps } from '../../types';
 
 import React, { useCallback, useContext, useEffect } from 'react';
 import { useParams } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { AccountContext, ActionContext, Button } from '../../components';
+import { AccountContext, Button } from '../../components';
 import useTranslation from '../../hooks/useTranslation';
 import { getAuthList, updateAuthorization } from '../../messaging';
 import { AccountSelection, Header } from '../../partials';
@@ -20,7 +21,7 @@ function AccountManagement ({ className }: Props): React.ReactElement<Props> {
   const { url } = useParams<{url: string}>();
   const { selectedAccounts = [], setSelectedAccounts } = useContext(AccountContext);
   const { t } = useTranslation();
-  const onAction = useContext(ActionContext);
+  const { goBack } = useHistory();
 
   useEffect(() => {
     getAuthList()
@@ -37,10 +38,10 @@ function AccountManagement ({ className }: Props): React.ReactElement<Props> {
   const _onApprove = useCallback(
     (): void => {
       updateAuthorization(selectedAccounts, url)
-        .then(() => onAction('/auth-list'))
+        .then(() => goBack())
         .catch(console.error);
     },
-    [onAction, selectedAccounts, url]
+    [goBack, selectedAccounts, url]
   );
 
   return (

--- a/packages/extension-ui/src/Popup/AuthManagement/AccountManagement.tsx
+++ b/packages/extension-ui/src/Popup/AuthManagement/AccountManagement.tsx
@@ -5,10 +5,9 @@ import type { ThemeProps } from '../../types';
 
 import React, { useCallback, useContext, useEffect } from 'react';
 import { useParams } from 'react-router';
-import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { AccountContext, Button } from '../../components';
+import { AccountContext, ActionContext, Button } from '../../components';
 import useTranslation from '../../hooks/useTranslation';
 import { getAuthList, updateAuthorization } from '../../messaging';
 import { AccountSelection, Header } from '../../partials';
@@ -21,7 +20,7 @@ function AccountManagement ({ className }: Props): React.ReactElement<Props> {
   const { url } = useParams<{url: string}>();
   const { selectedAccounts = [], setSelectedAccounts } = useContext(AccountContext);
   const { t } = useTranslation();
-  const { goBack } = useHistory();
+  const onAction = useContext(ActionContext);
 
   useEffect(() => {
     getAuthList()
@@ -38,10 +37,10 @@ function AccountManagement ({ className }: Props): React.ReactElement<Props> {
   const _onApprove = useCallback(
     (): void => {
       updateAuthorization(selectedAccounts, url)
-        .then(() => goBack())
+        .then(() => onAction('..'))
         .catch(console.error);
     },
-    [goBack, selectedAccounts, url]
+    [onAction, selectedAccounts, url]
   );
 
   return (

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -77,23 +77,24 @@ export default function Popup (): React.ReactElement {
   const [signRequests, setSignRequests] = useState<null | SigningRequest[]>(null);
   const [isWelcomeDone, setWelcomeDone] = useState(false);
   const [settingsCtx, setSettingsCtx] = useState<SettingsStruct>(startSettings);
-  const { goBack } = useHistory();
+  const history = useHistory();
 
   const _onAction = useCallback(
     (to?: string): void => {
       setWelcomeDone(window.localStorage.getItem('welcome_read') === 'ok');
 
       if (!to) {
-        console.error('Destination unspecified');
-
         return;
       }
 
       to === '..'
-        ? goBack()
+        // if we can't go gack from there, go to the home
+        ? history.length === 1
+          ? history.push('/')
+          : history.goBack()
         : window.location.hash = to;
     },
-    [goBack]
+    [history]
   );
 
   useEffect((): void => {

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -5,7 +5,7 @@ import type { AccountJson, AccountsContext, AuthorizeRequest, MetadataRequest, S
 import type { SettingsStruct } from '@polkadot/ui-settings/types';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Route, Switch } from 'react-router';
+import { Route, Switch, useHistory } from 'react-router';
 
 import { PHISHING_PAGE_REDIRECT } from '@polkadot/extension-base/defaults';
 import { canDerive } from '@polkadot/extension-base/utils';
@@ -77,16 +77,23 @@ export default function Popup (): React.ReactElement {
   const [signRequests, setSignRequests] = useState<null | SigningRequest[]>(null);
   const [isWelcomeDone, setWelcomeDone] = useState(false);
   const [settingsCtx, setSettingsCtx] = useState<SettingsStruct>(startSettings);
+  const { goBack } = useHistory();
 
   const _onAction = useCallback(
     (to?: string): void => {
       setWelcomeDone(window.localStorage.getItem('welcome_read') === 'ok');
 
-      if (to) {
-        window.location.hash = to;
+      if (!to) {
+        console.error('Destination unspecified');
+
+        return;
       }
+
+      to === '..'
+        ? goBack()
+        : window.location.hash = to;
     },
-    []
+    [goBack]
   );
 
   useEffect((): void => {

--- a/packages/extension-ui/src/partials/Header.tsx
+++ b/packages/extension-ui/src/partials/Header.tsx
@@ -5,10 +5,11 @@ import type { ThemeProps } from '../types';
 
 import { faArrowLeft, faCog, faPlusCircle, faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import logo from '../assets/pjs.svg';
+import { ActionContext } from '../components';
 import InputFilter from '../components/InputFilter';
 import Link from '../components/Link';
 import useOutsideClick from '../hooks/useOutsideClick';
@@ -43,6 +44,7 @@ function Header ({ children, className = '', onFilter, showAdd, showBackArrow, s
   const setMenuRef = useRef(null);
   const isConnected = useMemo(() => connectedTabsUrl.length >= 1
     , [connectedTabsUrl]);
+  const onAction = useContext(ActionContext);
 
   useEffect(() => {
     if (!showConnectedAccounts) {
@@ -91,21 +93,21 @@ function Header ({ children, className = '', onFilter, showAdd, showBackArrow, s
     [_onChangeFilter, isSearchOpen]
   );
 
+  const _onBackArrowClick = useCallback(
+    () => onAction('..')
+    , [onAction]);
+
   return (
     <div className={`${className} ${smallMargin ? 'smallMargin' : ''}`}>
       <div className='container'>
         <div className='branding'>
           {showBackArrow
             ? (
-              <Link
-                className='backlink'
-                to='/'
-              >
-                <FontAwesomeIcon
-                  className='arrowLeftIcon'
-                  icon={faArrowLeft}
-                />
-              </Link>
+              <FontAwesomeIcon
+                className='arrowLeftIcon'
+                icon={faArrowLeft}
+                onClick={_onBackArrowClick}
+              />
             )
             : (
               <img
@@ -300,9 +302,10 @@ export default React.memo(styled(Header)(({ theme }: Props) => `
   .arrowLeftIcon {
     color: ${theme.labelColor};
     margin-right: 1rem;
+    cursor: pointer;
   }
 
-  .backlink {
+  /* .backlink {
     color: ${theme.labelColor};
     min-height: 52px;
     text-decoration: underline;
@@ -311,7 +314,7 @@ export default React.memo(styled(Header)(({ theme }: Props) => `
     &:visited {
       color: ${theme.labelColor};
     }
-  }
+  } */
 
   &.smallMargin {
     margin-bottom: 15px;

--- a/packages/extension-ui/src/partials/Header.tsx
+++ b/packages/extension-ui/src/partials/Header.tsx
@@ -305,17 +305,6 @@ export default React.memo(styled(Header)(({ theme }: Props) => `
     cursor: pointer;
   }
 
-  /* .backlink {
-    color: ${theme.labelColor};
-    min-height: 52px;
-    text-decoration: underline;
-    width: min-content;
-
-    &:visited {
-      color: ${theme.labelColor};
-    }
-  } */
-
   &.smallMargin {
     margin-bottom: 15px;
   }


### PR DESCRIPTION
When coming from the home (by clicking on the new "connected" button), changing the set of connected accounts would then redirect to the "Website Management" page. This is unexpected since the users came from the home directly.

Using `goBack` here fixes this unexpected behavior.
