### PR TITLE
change textarea for div to show the mnemonic seed

### DIFF
--- a/packages/extension-ui/src/Popup/CreateAccount/CreateAccount.spec.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/CreateAccount.spec.tsx
@@ -72,8 +72,8 @@ describe('Create Account', () => {
   });
 
   describe('Phase 1', () => {
-    it('shows seed phrase in textarea', () => {
-      expect(wrapper.find('textarea').text()).toBe(exampleAccount.seed);
+    it('shows seed phrase in a span inside a div', () => {
+      expect(wrapper.find('.seedBox span').text()).toBe(exampleAccount.seed);
     });
 
     it('next step button is disabled when checkbox is not checked', () => {

--- a/packages/extension-ui/src/Popup/CreateAccount/Mnemonic.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/Mnemonic.tsx
@@ -12,26 +12,12 @@ interface Props {
   seed: string;
 }
 
-const onCopy = (): void => {
-  const mnemonicSeedTextElement = document.querySelector('textarea');
-
-  if (!mnemonicSeedTextElement) {
-    return;
-  }
-
-  mnemonicSeedTextElement.select();
-
-  // eslint-disable-next-line deprecation/deprecation
-  document.execCommand('copy');
-};
-
 function Mnemonic ({ onNextStep, seed }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [isMnemonicSaved, setIsMnemonicSaved] = useState(false);
   const { show } = useToast();
 
   const _onCopy = useCallback((): void => {
-    onCopy();
     show(t<string>('Copied'));
   }, [show, t]);
 

--- a/packages/extension-ui/src/components/BoxWithLabel.tsx
+++ b/packages/extension-ui/src/components/BoxWithLabel.tsx
@@ -1,0 +1,44 @@
+// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ThemeProps } from '../types.js';
+
+import React from 'react';
+import styled from 'styled-components';
+
+import Label from './Label.js';
+
+interface Props {
+  className?: string;
+  label: string;
+  value?: string;
+}
+
+function BoxWithLabel ({ className, label, value }: Props): React.ReactElement<Props> {
+  return (
+    <Label
+      className={className}
+      label={label}
+    >
+      <div className='seedBox'>
+        <span>{value}</span>
+      </div>
+    </Label>
+  );
+}
+
+export default styled(BoxWithLabel)(({ theme }: ThemeProps) => `
+  .seedBox {
+    background: ${theme.readonlyInputBackground};
+    box-shadow: none;
+    border-radius: ${theme.borderRadius};
+    border: 1px solid ${theme.inputBorderColor};
+    border-color: ${theme.inputBorderColor};
+    box-sizing: border-box;
+    display: block;
+    font-family: ${theme.fontFamily};
+    outline: none;
+    resize: none;
+    width: 100%;
+  }
+`);

--- a/packages/extension-ui/src/components/MnemonicSeed.tsx
+++ b/packages/extension-ui/src/components/MnemonicSeed.tsx
@@ -5,11 +5,12 @@ import type { ThemeProps } from '../types.js';
 
 import { faCopy } from '@fortawesome/free-regular-svg-icons';
 import React, { MouseEventHandler } from 'react';
+import CopyToClipboard from 'react-copy-to-clipboard';
 
 import useTranslation from '../hooks/useTranslation.js';
 import { styled } from '../styled.js';
 import ActionText from './ActionText.js';
-import TextAreaWithLabel from './TextAreaWithLabel.js';
+import BoxWithLabel from './BoxWithLabel.js';
 
 interface Props {
   seed: string;
@@ -22,20 +23,21 @@ function MnemonicSeed ({ className, onCopy, seed }: Props): React.ReactElement<P
 
   return (
     <div className={className}>
-      <TextAreaWithLabel
+      <BoxWithLabel
         className='mnemonicDisplay'
-        isReadOnly
         label={t<string>('Generated 12-word mnemonic seed:')}
         value={seed}
       />
       <div className='buttonsRow'>
-        <ActionText
-          className='copyBtn'
-          data-seed-action='copy'
-          icon={faCopy}
-          onClick={onCopy}
-          text={t<string>('Copy to clipboard')}
-        />
+        <CopyToClipboard text={seed}>
+          <ActionText
+            className='copyBtn'
+            data-seed-action='copy'
+            icon={faCopy}
+            onClick={onCopy}
+            text={t<string>('Copy to clipboard')}
+          />
+        </CopyToClipboard>
       </div>
     </div>
   );
@@ -54,7 +56,7 @@ export default styled(MnemonicSeed)(({ theme }: ThemeProps) => `
   }
 
   .mnemonicDisplay {
-    textarea {
+    .seedBox {
       color: ${theme.primaryColor};
       font-size: ${theme.fontSize};
       height: unset;


### PR DESCRIPTION
_context:_
the browser stores input/textarea values in tabs into plain text files in disk to restore content in case of a browser crash, unexpected closing or session restore. Multiple wallets and signers used textarea to show the generated Mnemonic Phrase seeds, obtaining the risk of getting into a situation like [this](https://halborn.com/halborn-discovers-critical-vulnerability-affecting-crypto-wallet-browser-extensions/).

_proposal:_
show the Mnemonic Phrase seed in a non input type HTML Element to avoid leaking of phrase in the cases mentioned before. With this change, it looks the same and for the user should not represent any change, there is a TODO related to the approach to the clipboard, as I still haven't check if using the Clipboard API requires asking for the additional permission to the browser.