### PR TITLE
Allow QR signing and add error when the account has no genesis

### DIFF
--- a/packages/extension-ui/src/Popup/Signing/Request/SignArea.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request/SignArea.tsx
@@ -17,12 +17,11 @@ interface Props {
   error: string | null;
   isExternal?: boolean;
   isFirst: boolean;
-  isSignable: boolean;
   setError: (value: string | null) => void;
   signId: string;
 }
 
-function SignArea ({ buttonText, className, error, isExternal, isFirst, isSignable, setError, signId }: Props): JSX.Element {
+function SignArea ({ buttonText, className, error, isExternal, isFirst, setError, signId }: Props): JSX.Element {
   const [savePass, setSavePass] = useState(false);
   const [isLocked, setIsLocked] = useState<boolean | null>(null);
   const [password, setPassword] = useState('');
@@ -97,7 +96,7 @@ function SignArea ({ buttonText, className, error, isExternal, isFirst, isSignab
 
   return (
     <ButtonArea className={className}>
-      {isSignable && isFirst && !isExternal && (
+      {isFirst && !isExternal && (
         <>
           {isLocked && (
             <Unlock

--- a/packages/extension-ui/src/Popup/Signing/Request/index.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request/index.tsx
@@ -6,7 +6,7 @@ import type { ExtrinsicPayload } from '@polkadot/types/interfaces';
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
 
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { TypeRegistry } from '@polkadot/types';
 import { decodeAddress } from '@polkadot/util-crypto';
@@ -44,11 +44,10 @@ function isRawPayload (payload: SignerPayloadJSON | SignerPayloadRaw): payload i
   return !!(payload as SignerPayloadRaw).data;
 }
 
-export default function Request ({ account: { accountIndex, addressOffset, isExternal, isHardware }, buttonText, isFirst, request, signId, url }: Props): React.ReactElement<Props> | null {
+export default function Request ({ account: { accountIndex, addressOffset, genesisHash, isExternal, isHardware }, buttonText, isFirst, request, signId, url }: Props): React.ReactElement<Props> | null {
   const onAction = useContext(ActionContext);
   const [{ hexBytes, payload }, setData] = useState<Data>({ hexBytes: null, payload: null });
   const [error, setError] = useState<string | null>(null);
-  const { accounts } = useContext(AccountContext);
   const { t } = useTranslation();
 
   useEffect((): void => {
@@ -135,7 +134,6 @@ export default function Request ({ account: { accountIndex, addressOffset, isExt
     );
   } else if (hexBytes !== null) {
     const { address, data } = request.payload as SignerPayloadRaw;
-    const account = accounts.find((account) => decodeAddress(account.address).toString() === decodeAddress(address).toString());
 
     return (
       <>
@@ -145,12 +143,12 @@ export default function Request ({ account: { accountIndex, addressOffset, isExt
             isExternal={isExternal}
           />
         </div>
-        {isExternal && !isHardware && account?.genesisHash
+        {isExternal && !isHardware && genesisHash
           ? (
             <Qr
               address={address}
               cmd={CMD_SIGN_MESSAGE}
-              genesisHash={account.genesisHash}
+              genesisHash={genesisHash}
               onSignature={_onSignature}
               payload={data}
             />
@@ -163,7 +161,7 @@ export default function Request ({ account: { accountIndex, addressOffset, isExt
           )
         }
         <VerticalSpace />
-        {isExternal && !isHardware && !account?.genesisHash && (
+        {isExternal && !isHardware && !genesisHash && (
           <>
             <Warning isDanger>{t('"Allow use on any network" is not supported to show a QR code. You must associate this account with a network.')}</Warning>
             <VerticalSpace />

--- a/packages/extension-ui/src/Popup/Signing/Request/index.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request/index.tsx
@@ -6,12 +6,11 @@ import type { ExtrinsicPayload } from '@polkadot/types/interfaces';
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
 
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { TypeRegistry } from '@polkadot/types';
-import { decodeAddress } from '@polkadot/util-crypto';
 
-import { AccountContext, ActionContext, Address, VerticalSpace, Warning } from '../../../components';
+import { ActionContext, Address, VerticalSpace, Warning } from '../../../components';
 import { useTranslation } from '../../../components/translate';
 import { approveSignSignature } from '../../../messaging';
 import Bytes from '../Bytes';

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -161,10 +161,6 @@
   "I want to export all my accounts": "",
   "Notifications": "",
   "Search by name or network...": "",
-  "Message signing is not supported for hardware wallets.": "",
-  "Message signing is not supported for QR wallets.": "",
-  "Raw data signing is not supported for hardware wallets.": "",
-  "Raw data signing is not supported for QR wallets.": "",
   "Select all": "",
   "Accounts connected to {{url}}": "",
   "Connect {{total}} account(s)": "",
@@ -173,5 +169,6 @@
   "Understood": "",
   "Ask again later": "",
   "no accounts": "",
-  "all accounts": ""
+  "all accounts": "",
+  "Message signing is not supported for hardware wallets.": ""
 }


### PR DESCRIPTION
This PR reverts https://github.com/polkadot-js/extension/pull/1053 now that Signer supports raw bytes signing again thanks to  https://github.com/paritytech/parity-signer/pull/1332 

Small bonus, I added an error message in case the account has no `genesisHash` associated. This is mandatory for QR generation and is a common source of confusion. Before having this message, the screen would only show the bytes, with no signing button or QR code, leaving users with no clue about what's going on. 

I tested it with Signer `master` branch, Polkassembly and the Signing tool of apps.

![image](https://user-images.githubusercontent.com/33178835/195588062-8d805548-419f-462c-bfea-4768758ceb8e.png)
![image](https://user-images.githubusercontent.com/33178835/195588109-0aa63841-dc3d-4f61-94aa-85fd8794c02d.png)
![image](https://user-images.githubusercontent.com/33178835/195588089-c381dba9-3b4a-4047-ad79-926f932363a1.png)
