### PR TITLE
Fixed loading error of dev version on Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Steps to build the extension and view your changes in a browser:
   - Firefox:
     - go to `about:debugging#addons`
     - check "Enable add-on debugging"
-    - click on "Load Temporary Add-on" and point to `packages/extension/build/manifest.json`
+    - click on "Load Temporary Add-on" and point to `packages/extension/build/index.html`
     - if developing, after making changes - reload the extension
 3. When visiting `https://polkadot.js.org/apps/` it will inject the extension
 


### PR DESCRIPTION
Fixed [this](https://substrate.stackexchange.com/questions/5371/index-html-file-not-found-on-firefox-after-building-dev-version-of-polkadot-js-e) this problem. You should load the index.html file on Firefox instead of the manifest.json file.