### PR TITLE
Always set metadata before signing

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -372,14 +372,18 @@ export default class Extension {
       const metadata = this.#state.knownMetadata.find(({ genesisHash }) => genesisHash === payload.genesisHash);
 
       if (metadata) {
-        registry = metadataExpand(metadata, false, payload.signedExtensions).registry;
-      } else {
-        registry = new TypeRegistry();
+        // we have metadata, expand it and extract the info/registry
+        const expanded = metadataExpand(metadata, false);
 
-        // set the extensions before signing (only payload info)
+        registry = expanded.registry;
+        registry.setSignedExtensions(payload.signedExtensions, expanded.definition.userExtensions);
+      } else {
+        // we have no metadata, create a new registry
+        registry = new TypeRegistry();
         registry.setSignedExtensions(payload.signedExtensions);
       }
     } else {
+      // for non-payload, just create a registry to use
       registry = new TypeRegistry();
     }
 

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -6,12 +6,10 @@
 import type { InjectedAccount, InjectedMetadataKnown, MetadataDef, ProviderList, ProviderMeta } from '@polkadot/extension-inject/types';
 import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta } from '@polkadot/keyring/types';
 import type { JsonRpcResponse } from '@polkadot/rpc-provider/types';
-import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
+import type { Registry, SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { KeyringPairs$Json } from '@polkadot/ui-keyring/types';
 import type { HexString } from '@polkadot/util/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
-
-import { TypeRegistry } from '@polkadot/types';
 
 import { ALLOWED_PATH } from '../defaults';
 import { AuthResponse, AuthUrls } from './handlers/State';
@@ -396,7 +394,7 @@ export type MessageTypesWithNoSubscriptions = Exclude<MessageTypes, keyof Subscr
 export interface RequestSign {
   readonly payload: SignerPayloadJSON | SignerPayloadRaw;
 
-  sign (registry: TypeRegistry, pair: KeyringPair): { signature: HexString };
+  sign (registry: Registry, pair: KeyringPair): { signature: HexString };
 }
 
 export interface RequestJsonRestore {

--- a/packages/extension-chains/src/bundle.ts
+++ b/packages/extension-chains/src/bundle.ts
@@ -19,7 +19,7 @@ const definitions = new Map<string, MetadataDef>(
 
 const expanded = new Map<string, Chain>();
 
-export function metadataExpand (definition: MetadataDef, isPartial = false): Chain {
+export function metadataExpand (definition: MetadataDef, isPartial = false, extensions?: string[]): Chain {
   const cached = expanded.get(definition.genesisHash);
 
   if (cached && cached.specVersion === definition.specVersion) {
@@ -42,7 +42,7 @@ export function metadataExpand (definition: MetadataDef, isPartial = false): Cha
   const hasMetadata = !!metaCalls && !isPartial;
 
   if (hasMetadata) {
-    registry.setMetadata(new Metadata(registry, base64Decode(metaCalls)), undefined, userExtensions);
+    registry.setMetadata(new Metadata(registry, base64Decode(metaCalls)), extensions, userExtensions);
   }
 
   const isUnknown = genesisHash === '0x';

--- a/packages/extension-chains/src/bundle.ts
+++ b/packages/extension-chains/src/bundle.ts
@@ -19,7 +19,7 @@ const definitions = new Map<string, MetadataDef>(
 
 const expanded = new Map<string, Chain>();
 
-export function metadataExpand (definition: MetadataDef, isPartial = false, extensions?: string[]): Chain {
+export function metadataExpand (definition: MetadataDef, isPartial = false): Chain {
   const cached = expanded.get(definition.genesisHash);
 
   if (cached && cached.specVersion === definition.specVersion) {
@@ -42,7 +42,7 @@ export function metadataExpand (definition: MetadataDef, isPartial = false, exte
   const hasMetadata = !!metaCalls && !isPartial;
 
   if (hasMetadata) {
-    registry.setMetadata(new Metadata(registry, base64Decode(metaCalls)), extensions, userExtensions);
+    registry.setMetadata(new Metadata(registry, base64Decode(metaCalls)), undefined, userExtensions);
   }
 
   const isUnknown = genesisHash === '0x';


### PR DESCRIPTION
Use the actual registry assigned to a specific instance of metadata for signing operations.

Closes #1090 (Replaces) 
Closes #907 