### PR TITLE
Resize for popup for consistent size on Windows and Mac OS

### DIFF
--- a/packages/extension-ui/src/createView.tsx
+++ b/packages/extension-ui/src/createView.tsx
@@ -10,6 +10,24 @@ import { HashRouter } from 'react-router-dom';
 import { View } from './components/index.js';
 
 export default function createView (Entry: React.ComponentType, rootId = 'root'): void {
+  const targetInnerWidth = 560;
+  const targetInnerHeight = 600;
+
+  // Popup window size is initially set via chrome.windows.create, however
+  // it will result in different inner dimensions on Windows and Mac OS.
+  // This is a hacky way to have a consistent popup size
+  if (
+    window.innerWidth !== targetInnerWidth ||
+    window.innerHeight !== targetInnerHeight
+  ) {
+    const newOuterWidth =
+      targetInnerWidth + (window.outerWidth - window.innerWidth);
+    const newOuterHeight =
+      targetInnerHeight + (window.outerHeight - window.innerHeight);
+
+    window.resizeTo(newOuterWidth, newOuterHeight);
+  }
+
   const rootElement = document.getElementById(rootId);
 
   if (!rootElement) {


### PR DESCRIPTION
Due to the differences in the way that Windows and Mac OS renders the window frames and borders it results in inconsistent popup sizes which obscures some information. e.g.  the "Ask again later" option as shown below for Windows. This only happens when a popup is created and not when clicking on the extension icon. `chrome.windows.create` doesn't have a clean way to handle both OS's. This PR is a hacky way to try to handle both OS's.

Original `chrome.windows.create` outer dimensions = 560x621 (from `POPUP_WINDOW_OPTS`)
Resulting Windows popup inner dimension = 544x582
![image](https://user-images.githubusercontent.com/42175565/228629077-f888dc91-c5ae-46fd-a702-be5a12ee0d00.png)

After resize to 560x600 inner dimension
![image](https://user-images.githubusercontent.com/42175565/228629450-58112831-82b3-4109-8763-8ce081704a3b.png)

