### PR TITLE
Remove old/deprecated watch (only use build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Find out more about how to use the extension as a Dapp developper, cookbook, as 
 
 Steps to build the extension and view your changes in a browser:
 
-1. Build via `yarn build` or `yarn watch`
+1. Build via `yarn build`
 2. Install the extension
   - Chrome:
     - go to `chrome://extensions/`

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
     "clean": "polkadot-dev-clean-build",
     "lint": "polkadot-dev-run-lint",
     "postinstall": "polkadot-dev-yarn-only",
-    "start": "yarn watch",
     "test": "EXTENSION_PREFIX='test' polkadot-dev-run-test --loader ./packages/extension-mocks/src/loader-empty.js --env browser ^:.spec.tsx",
-    "test:one": "EXTENSION_PREFIX='test' polkadot-dev-run-test --env browser",
-    "watch": "cd packages/extension && yarn polkadot-exec-webpack --config webpack.watch.cjs --mode development --watch"
+    "test:one": "EXTENSION_PREFIX='test' polkadot-dev-run-test --env browser"
   },
   "devDependencies": {
     "@polkadot/dev": "^0.76.29",


### PR DESCRIPTION
`yarn watch` has been inoperable for a very long time. This removes the dangling `yarn watch` & `yarn start` that still referenced the (long removed) config.

As reported in https://github.com/polkadot-js/extension/issues/1294