### PR TITLE
Fix: Prevent authorization request from incorrect origin due to chrome pre-rendering fixes #1293 

### DIFF
--- a/packages/extension-base/src/background/handlers/index.ts
+++ b/packages/extension-base/src/background/handlers/index.ts
@@ -22,13 +22,13 @@ export default function handler<TMessageType extends MessageTypes> ({ id, messag
   const isExtension = !port || port?.name === extensionPortName;
   const sender = port?.sender;
 
-  if (!sender) {
-    throw new Error('Unable to extract message sender');
+  if (!isExtension && !sender) {
+      throw new Error('Unable to extract message sender');
   }
 
   const from = isExtension
     ? 'extension'
-    : (sender.tab?.url) || sender.url || '<unknown>';
+    : sender?.url || sender?.tab?.url ||  '<unknown>';
   const source = `${from}: ${id}: ${message}`;
 
   console.log(` [in] ${source}`); // :: ${JSON.stringify(request)}`);

--- a/packages/extension-base/src/background/handlers/index.ts
+++ b/packages/extension-base/src/background/handlers/index.ts
@@ -23,12 +23,12 @@ export default function handler<TMessageType extends MessageTypes> ({ id, messag
   const sender = port?.sender;
 
   if (!isExtension && !sender) {
-      throw new Error('Unable to extract message sender');
+    throw new Error('Unable to extract message sender');
   }
 
   const from = isExtension
     ? 'extension'
-    : sender?.url || sender?.tab?.url ||  '<unknown>';
+    : sender?.url || sender?.tab?.url || '<unknown>';
   const source = `${from}: ${id}: ${message}`;
 
   console.log(` [in] ${source}`); // :: ${JSON.stringify(request)}`);


### PR DESCRIPTION
We cannot rely on `sender.tab.url` when chrome preloads and prerenders pages as it will not match the url of the site being loaded. This PR changes the primary from to `sender.url` and only uses `sender.tab.url` if `sender.url` is not available.

See discussion in #1293 

Edit:
Also PR #1278 introduced a bug by adding
```
  if (!sender) {
    throw new Error('Unable to extract message sender');
  }
```
in the case of [getActiveTabs](https://github.com/polkadot-js/extension/blob/128738181afb5796e326632c60f861e278e6481b/packages/extension/src/background.ts#L32) no port is passed causing this to throw an error preventing the extension from initializing.

This PR fixes that by only throwing `if (!isExtension && !sender)`