### PR TITLE
Enable raw payloads to be signed in extension

### DIFF
--- a/packages/extension-base/src/background/RequestBytesSign.ts
+++ b/packages/extension-base/src/background/RequestBytesSign.ts
@@ -7,7 +7,7 @@ import type { SignerPayloadRaw } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
 import type { RequestSign } from './types.js';
 
-import { u8aToHex, u8aWrapBytes } from '@polkadot/util';
+import { u8aToHex, u8aToU8a, u8aWrapBytes } from '@polkadot/util';
 
 export default class RequestBytesSign implements RequestSign {
   public readonly payload: SignerPayloadRaw;
@@ -20,7 +20,7 @@ export default class RequestBytesSign implements RequestSign {
     return {
       signature: u8aToHex(
         pair.sign(
-          u8aWrapBytes(this.payload.data)
+          ['raw'].includes(this.payload.type) ? u8aToU8a(this.payload.data) : u8aWrapBytes(this.payload.data)
         )
       )
     };


### PR DESCRIPTION
this PR closes #1357 by adding a type 'raw' signature that enables developers to sign raw payloads using the 'signRaw' method in the extension and avoid forced data manipulation in the signing process.