### PR TITLE
Add firefox installation from src instructions

### DIFF
--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -15,5 +15,6 @@ jobs:
         node-version: 'lts/*'
     - name: ${{ matrix.step }}
       run: |
+        corepack enable
         yarn install --immutable
         yarn ${{ matrix.step }}

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -27,5 +27,6 @@ jobs:
         GH_RELEASE_FILES: master-build.zip,master-src.zip
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
+        corepack enable
         yarn install --immutable
         yarn ${{ matrix.step }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,5 +11,3 @@ logFilters:
     level: discard
 
 nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-4.1.1.cjs

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Find out more about how to use the extension as a Dapp developper, cookbook, as 
 ## Firefox installation from source instructions.
 
 1. Uncompress `master-src.zip`
+2. Run `corepack enable` [More information](https://github.com/nodejs/corepack?tab=readme-ov-file#corepack-enable--name)
 2. Install dependencies via `yarn install`
 3. Build all packages via `yarn build`
   - The `/packages/extension/build` will contain the exact code used in the add-on

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Find out more about how to use the extension as a Dapp developper, cookbook, as 
 Steps to build the extension and view your changes in a browser:
 
 1. Build via `yarn build`
+  - NOTE: You may need to enable corepack by running `corepack enable`
 2. Install the extension
   - Chrome:
     - go to `chrome://extensions/`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # polkadot{.js} extension
 
-**Important** Please be aware, this repository has not had a release to the google or firefox store in over 2 years which leaves the store version out of sync with the latest release of this extension. 
-
 A very simple scaffolding browser extension that injects a [@polkadot/api](https://github.com/polkadot-js/api) Signer into a page, along with any associated accounts, allowing for use by any dapp. This is an extensible POC implementation of a Polkadot/Substrate browser signer.
 
 As it stands, it does one thing: it _only_ manages accounts and allows the signing of transactions with those accounts. It does not inject providers for use by dapps at this early point, nor does it perform wallet functions where it constructs and submits txs to the network.
@@ -15,6 +13,14 @@ As it stands, it does one thing: it _only_ manages accounts and allows the signi
 
 ## Documentation and examples
 Find out more about how to use the extension as a Dapp developper, cookbook, as well as answers to most frequent questions in the [Polkadot-js extension documentation](https://polkadot.js.org/docs/extension/)
+
+## Firefox installation from source instructions.
+
+1. Uncompress `master-src.zip`
+2. Install dependencies via `yarn install`
+3. Build all packages via `yarn build`
+  - The `/packages/extension/build` will contain the exact code used in the add-on
+4. To regenerate the dst, and src compressed files run: `yarn build:zip` 
 
 ## Development version
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:rollup": "polkadot-exec-rollup --config",
     "build:zip": "yarn build:zip:dst && yarn build:zip:src",
     "build:zip:dst": "rm -rf ./master-build.zip && cd packages/extension/build && zip -r -FS ../../../master-build.zip .",
-    "build:zip:src": "rm -rf ./master-src.zip && zip -r -x '*build/*' -x '*node_modules*' -FS ./master-src.zip packages .editorconfig .eslintignore .eslintrc.js babel.config.cjs CHANGELOG.md CONTRIBUTING.md i18next-scanner.config.js LICENSE package.json README.md tsconfig.json yarn.lock",
+    "build:zip:src": "rm -rf ./master-src.zip && zip -r -x '*build/*' -x '*node_modules*' -FS ./master-src.zip packages .editorconfig eslint.config.js rollup.config.js CHANGELOG.md CONTRIBUTING.md i18next-scanner.config.cjs LICENSE package.json README.md tsconfig.json yarn.lock .yarnrc.yml tsconfig.base.json tsconfig.build.json tsconfig.eslint.json tsconfig.webpack.json",
     "clean": "polkadot-dev-clean-build",
     "lint": "polkadot-dev-run-lint",
     "postinstall": "polkadot-dev-yarn-only",


### PR DESCRIPTION
closes: https://github.com/polkadot-js/extension/issues/1370

## Summary

The following PR:

- Adds instructions for Firefox to build the exact build from the zipped source code
- Adjusts the source build script to ensure you can build from source.
- Adjusts .yarnrc.yml to ensure all config works in a bare enviornment