### PR TITLE
Fix: forget account for legacy account without authorizedAccounts

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -121,11 +121,11 @@ export default class Extension {
 
     // cycle through authUrls and prepare the array of diff
     Object.entries(this.#state.authUrls).forEach(([url, urlInfo]) => {
-      if (!urlInfo.authorizedAccounts.includes(address)) {
-        return;
+      // Note that urlInfo.authorizedAccounts may be undefined if this account was created
+      // before the funcrionality was introduced, and was never not authorized on any website yet
+      if (urlInfo.authorizedAccounts?.includes(address)) {
+        authorizedAccountsDiff.push([url, urlInfo.authorizedAccounts.filter((previousAddress) => previousAddress !== address)]);
       }
-
-      authorizedAccountsDiff.push([url, urlInfo.authorizedAccounts.filter((previousAddress) => previousAddress !== address)]);
     });
 
     this.#state.updateAuthorizedAccounts(authorizedAccountsDiff);

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -121,8 +121,8 @@ export default class Extension {
 
     // cycle through authUrls and prepare the array of diff
     Object.entries(this.#state.authUrls).forEach(([url, urlInfo]) => {
-      // Note that urlInfo.authorizedAccounts may be undefined if this account was created
-      // before the funcrionality was introduced, and was never not authorized on any website yet
+      // Note that urlInfo.authorizedAccounts may be undefined if this website entry
+      // was created before the "account authorization per website" functionality was introduced
       if (urlInfo.authorizedAccounts?.includes(address)) {
         authorizedAccountsDiff.push([url, urlInfo.authorizedAccounts.filter((previousAddress) => previousAddress !== address)]);
       }


### PR DESCRIPTION
closes #1376 

I managed to reproduce, here are the details for this to happen:
- you need a state with the old version of the extension where you have a non empty `authUrls` list, which means that you have ever connected at least an account to a dapp. Checkout commit 4edd9cd34face13d09a6c1c64edfc6797db800a1 for instance.
- once this is done, upgrade the extension to master: there's no state migration per se
- if you ever visit a website you had visited before, one that is present in your `authUrls`, then you'll need to set the authorizations for this website again, as in, it used to be available for all accounts, now you need to specify. Doing so will set `authorizedAccounts` for this website.
- if you try to forget an account, and you have at least one entry in your `authorizedAccounts` that doesn't have `authUrls`, then it'll crash.

The fix is super simple once this is clear, `authorizedAccounts` can be undefined and shouldn't prevent us from removing an account.