### PR TITLE
Feature/select web3 extension

### DIFF
--- a/packages/extension-dapp/src/bundle.ts
+++ b/packages/extension-dapp/src/bundle.ts
@@ -101,9 +101,19 @@ async function filterEnable (caller: 'web3Accounts' | 'web3AccountsSubscribe', e
 }
 
 /**
- * @summary Enables all the providers found on the injected window interface
+ * @summary Return record of all providers found on the injected window interface
  * @description
- * Enables all injected extensions that has been found on the page. This
+ * Enables all or one injected extensions that has been found on the page. This
+ * should be called before making use of any other web3* functions.
+ */
+export function getAllAvailableWebExtensions(): Record<string, InjectedWindowProvider> {
+  return win.injectedWeb3;
+}
+
+/**
+ * @summary Enables all or one the provider(s) found on the injected window interface
+ * @description
+ * Enables all or one injected extensions that has been found on the page. This
  * should be called before making use of any other web3* functions.
  */
 export function web3Enable (originName: string, compatInits: (() => Promise<boolean>)[] = [], selectedExtensionByUser?: {[key:string]: InjectedWindowProvider}): Promise<InjectedExtension[]> {


### PR DESCRIPTION
Hi there guys! I working on one of Web3 app for staking using dApp, and we wanna add possibility for staking Polkadot on our validators for user with there web3 wallets. But I meet some problem:
Imagine that user have two extension which can injected in dApp (Polkadot.js & SubWallet for example) and when we call web3Enable func it start authorization to all of them, it's some not clear for user (why you need all my extension??) and some harder to develop for developers. So, I propose add new func which return all available extensions for developer and he can shown list for user, and user can choose one only. And of course add new args for web3Enable method for enable only one of extenstion. 
Hope you accept this, thank's for your attention, time, and work, Polkadot is amazing project and we belive in big success of it in future))