### PR TITLE
Update XCM Analyser to v1.3.0 - fix for xcm v4

### DIFF
--- a/packages/extension-ui/package.json
+++ b/packages/extension-ui/package.json
@@ -22,7 +22,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@paraspell/xcm-analyser": "^1.2.0",
+    "@paraspell/xcm-analyser": "^1.3.0",
     "@polkadot/api": "^12.0.2",
     "@polkadot/extension-base": "0.48.2",
     "@polkadot/extension-chains": "0.48.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,12 +633,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@paraspell/xcm-analyser@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@paraspell/xcm-analyser@npm:1.2.0"
+"@paraspell/xcm-analyser@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@paraspell/xcm-analyser@npm:1.3.0"
   dependencies:
     zod: "npm:^3.22.4"
-  checksum: 10/920f211583e2d01b0dc26812b010489c2611dd65244aba461efbc6688fdda0e18bb8820a71e5490cb96650c4d22ac5ae1eb86e04845b9601f083418032b7dc9c
+  checksum: 10/c0229a3e99c923e6ef5642a0148c1549a818813b2135c85a3ca0e46f42dff45124edcde1bc35a504752d13f1f92c1612adf7c4145d62648213035ca4e599acf4
   languageName: node
   linkType: hard
 
@@ -980,7 +980,7 @@ __metadata:
     "@fortawesome/free-regular-svg-icons": "npm:^6.5.1"
     "@fortawesome/free-solid-svg-icons": "npm:^6.5.1"
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
-    "@paraspell/xcm-analyser": "npm:^1.2.0"
+    "@paraspell/xcm-analyser": "npm:^1.3.0"
     "@polkadot/api": "npm:^12.0.2"
     "@polkadot/extension-base": "npm:0.48.2"
     "@polkadot/extension-chains": "npm:0.48.2"


### PR DESCRIPTION
This PR features an update to XCM-Analyser to v1.3.0. This version contains a fix for the latest XCM version - v4 where x1 multilocations are no longer considered as objects "{}" but as arrays "[]" to remain consistent with other multilocations.

With kind regards
Team ParaSpell