### PR TITLE
Add LedgerGeneric support to the extension [WIP]

### DIFF
--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -4,7 +4,7 @@
 /* global chrome */
 
 import type { Subscription } from 'rxjs';
-import type { InjectedAccount, InjectedMetadataKnown, MetadataDef, ProviderMeta } from '@polkadot/extension-inject/types';
+import type { InjectedAccount, InjectedMetadataKnown, MetadataDef, ProviderMeta, RawMetadataDef } from '@polkadot/extension-inject/types';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { JsonRpcResponse } from '@polkadot/rpc-provider/types';
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
@@ -136,6 +136,10 @@ export default class Tabs {
     return this.#state.injectMetadata(url, request);
   }
 
+  private rawMetadataProvide (url: string, request: RawMetadataDef): Promise<boolean> {
+    return this.#state.injectRawMetadata(url, request);
+  }
+
   private metadataList (_url: string): InjectedMetadataKnown[] {
     return this.#state.knownMetadata.map(({ genesisHash, specVersion }) => ({
       genesisHash,
@@ -245,6 +249,9 @@ export default class Tabs {
 
       case 'pub(metadata.provide)':
         return this.metadataProvide(url, request as MetadataDef);
+
+      case 'pub(metadata.provideRaw)':
+        return this.rawMetadataProvide(url, request as RawMetadataDef);
 
       case 'pub(ping)':
         return Promise.resolve(true);

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable no-use-before-define */
 
-import type { InjectedAccount, InjectedMetadataKnown, MetadataDef, ProviderList, ProviderMeta } from '@polkadot/extension-inject/types';
+import type { InjectedAccount, InjectedMetadataKnown, MetadataDef, ProviderList, ProviderMeta, RawMetadataDef } from '@polkadot/extension-inject/types';
 import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta } from '@polkadot/keyring/types';
 import type { JsonRpcResponse } from '@polkadot/rpc-provider/types';
 import type { Registry, SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
@@ -67,6 +67,12 @@ export interface MetadataRequest {
   url: string;
 }
 
+export interface RawMetadataRequest {
+  id: string;
+  request: RawMetadataDef;
+  url: string;
+}
+
 export interface SigningRequest {
   account: AccountJson;
   id: string;
@@ -106,9 +112,12 @@ export interface RequestSignatures {
   'pri(json.batchRestore)': [RequestBatchRestore, void];
   'pri(json.account.info)': [KeyringPair$Json, ResponseJsonGetAccountInfo];
   'pri(metadata.approve)': [RequestMetadataApprove, boolean];
+  'pri(metadata.approveRaw)': [RequestMetadataApprove, boolean];
   'pri(metadata.get)': [string | null, MetadataDef | null];
+  'pri(metadata.getRaw)': [string | null, RawMetadataDef | null];
   'pri(metadata.reject)': [RequestMetadataReject, boolean];
   'pri(metadata.requests)': [RequestMetadataSubscribe, boolean, MetadataRequest[]];
+  'pri(metadata.requestsRaw)': [RequestMetadataSubscribe, boolean, RawMetadataRequest[]];
   'pri(metadata.list)': [null, MetadataDef[]];
   'pri(ping)': [null, boolean];
   'pri(seed.create)': [RequestSeedCreate, ResponseSeedCreate];
@@ -129,6 +138,7 @@ export interface RequestSignatures {
   'pub(extrinsic.sign)': [SignerPayloadJSON, ResponseSigning];
   'pub(metadata.list)': [null, InjectedMetadataKnown[]];
   'pub(metadata.provide)': [MetadataDef, boolean];
+  'pub(metadata.provideRaw)': [RawMetadataDef, boolean];
   'pub(phishing.redirectIfDenied)': [null, boolean];
   'pub(ping)': [null, boolean];
   'pub(rpc.listProviders)': [void, ResponseRpcListProviders];

--- a/packages/extension-base/src/page/Injected.ts
+++ b/packages/extension-base/src/page/Injected.ts
@@ -5,7 +5,7 @@ import type { Injected } from '@polkadot/extension-inject/types';
 import type { SendRequest } from './types.js';
 
 import Accounts from './Accounts.js';
-import Metadata from './Metadata.js';
+import { Metadata, RawMetadata} from './Metadata.js';
 import PostMessageProvider from './PostMessageProvider.js';
 import Signer from './Signer.js';
 
@@ -14,6 +14,8 @@ export default class implements Injected {
 
   public readonly metadata: Metadata;
 
+  public readonly rawMetadata: RawMetadata;
+
   public readonly provider: PostMessageProvider;
 
   public readonly signer: Signer;
@@ -21,6 +23,7 @@ export default class implements Injected {
   constructor (sendRequest: SendRequest) {
     this.accounts = new Accounts(sendRequest);
     this.metadata = new Metadata(sendRequest);
+    this.rawMetadata = new RawMetadata(sendRequest);
     this.provider = new PostMessageProvider(sendRequest);
     this.signer = new Signer(sendRequest);
 

--- a/packages/extension-base/src/page/Metadata.ts
+++ b/packages/extension-base/src/page/Metadata.ts
@@ -1,13 +1,13 @@
 // Copyright 2019-2024 @polkadot/extension-base authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { InjectedMetadata, InjectedMetadataKnown, MetadataDef } from '@polkadot/extension-inject/types';
+import type { InjectedMetadata, InjectedMetadataKnown, InjectedRawMetadata, MetadataDef, RawMetadataDef } from '@polkadot/extension-inject/types';
 import type { SendRequest } from './types.js';
 
 // External to class, this.# is not private enough (yet)
 let sendRequest: SendRequest;
 
-export default class Metadata implements InjectedMetadata {
+export class Metadata implements InjectedMetadata {
   constructor (_sendRequest: SendRequest) {
     sendRequest = _sendRequest;
   }
@@ -18,5 +18,19 @@ export default class Metadata implements InjectedMetadata {
 
   public provide (definition: MetadataDef): Promise<boolean> {
     return sendRequest('pub(metadata.provide)', definition);
+  }
+}
+
+export class RawMetadata implements InjectedRawMetadata {
+  constructor (_sendRequest: SendRequest) {
+    sendRequest = _sendRequest;
+  }
+
+  public get (): Promise<InjectedMetadataKnown[]> {
+    return sendRequest('pub(metadata.list)');
+  }
+
+  public provide (definition: RawMetadataDef): Promise<boolean> {
+    return sendRequest('pub(metadata.provideRaw)', definition);
   }
 }

--- a/packages/extension-base/src/stores/Metadata.ts
+++ b/packages/extension-base/src/stores/Metadata.ts
@@ -1,12 +1,22 @@
 // Copyright 2019-2024 @polkadot/extension-base authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { MetadataDef } from '@polkadot/extension-inject/types';
+import type { MetadataDef, RawMetadataDef } from '@polkadot/extension-inject/types';
 
 import { EXTENSION_PREFIX } from '../defaults.js';
 import BaseStore from './Base.js';
 
-export default class MetadataStore extends BaseStore<MetadataDef> {
+export class MetadataStore extends BaseStore<MetadataDef> {
+  constructor () {
+    super(
+      EXTENSION_PREFIX && EXTENSION_PREFIX !== 'polkadot{.js}'
+        ? `${EXTENSION_PREFIX}metadata`
+        : 'metadata'
+    );
+  }
+}
+
+export class RawMetadataStore extends BaseStore<RawMetadataDef> {
   constructor () {
     super(
       EXTENSION_PREFIX && EXTENSION_PREFIX !== 'polkadot{.js}'

--- a/packages/extension-base/src/stores/index.ts
+++ b/packages/extension-base/src/stores/index.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { default as AccountsStore } from './Accounts.js';
-export { default as MetadataStore } from './Metadata.js';
+export { MetadataStore, RawMetadataStore } from './Metadata.js';

--- a/packages/extension-chains/src/bundle.ts
+++ b/packages/extension-chains/src/bundle.ts
@@ -1,7 +1,7 @@
 // Copyright 2019-2024 @polkadot/extension-chains authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { MetadataDef } from '@polkadot/extension-inject/types';
+import type { MetadataDef, RawMetadataDef } from '@polkadot/extension-inject/types';
 import type { ChainProperties } from '@polkadot/types/interfaces';
 import type { Chain } from './types.js';
 
@@ -16,7 +16,7 @@ export { packageInfo } from './packageInfo.js';
 const definitions = new Map<string, MetadataDef>(
   // [kusama].map((def) => [def.genesisHash, def])
 );
-
+const rawDefinitions = new Map<string, RawMetadataDef>();
 const expanded = new Map<string, Chain>();
 
 export function metadataExpand (definition: MetadataDef, isPartial = false): Chain {
@@ -82,6 +82,14 @@ export function addMetadata (def: MetadataDef): void {
   definitions.set(def.genesisHash, def);
 }
 
+export function addRawMetadata (def: RawMetadataDef): void {
+  rawDefinitions.set(def.genesisHash, def);
+}
+
 export function knownMetadata (): MetadataDef[] {
   return [...definitions.values()];
+}
+
+export function knownRawMetadata (): RawMetadataDef[] {
+  return [...rawDefinitions.values()];
 }

--- a/packages/extension-inject/src/types.ts
+++ b/packages/extension-inject/src/types.ts
@@ -69,6 +69,11 @@ export interface MetadataDef extends MetadataDefBase {
   userExtensions?: ExtDef;
 }
 
+export interface RawMetadataDef {
+  genesisHash: string;
+  rawMetadata: HexString;
+}
+
 export interface InjectedMetadataKnown {
   genesisHash: string;
   specVersion: number;
@@ -77,6 +82,11 @@ export interface InjectedMetadataKnown {
 export interface InjectedMetadata {
   get: () => Promise<InjectedMetadataKnown[]>;
   provide: (definition: MetadataDef) => Promise<boolean>;
+}
+
+export interface InjectedRawMetadata {
+  get: () => Promise<InjectedMetadataKnown[]>;
+  provide: (definition: RawMetadataDef) => Promise<boolean>;
 }
 
 export type ProviderList = Record<string, ProviderMeta>

--- a/packages/extension-ui/src/MetadataCache.ts
+++ b/packages/extension-ui/src/MetadataCache.ts
@@ -1,9 +1,11 @@
 // Copyright 2019-2024 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { MetadataDef } from '@polkadot/extension-inject/types';
+import type { MetadataDef, RawMetadataDef } from '@polkadot/extension-inject/types';
 
 const metadataGets = new Map<string, Promise<MetadataDef | null>>();
+const rawMetadataGets = new Map<string, Promise<RawMetadataDef | null>>();
+
 
 export function getSavedMeta (genesisHash: string): Promise<MetadataDef | null> | undefined {
   return metadataGets.get(genesisHash);
@@ -11,4 +13,12 @@ export function getSavedMeta (genesisHash: string): Promise<MetadataDef | null> 
 
 export function setSavedMeta (genesisHash: string, def: Promise<MetadataDef | null>): Map<string, Promise<MetadataDef | null>> {
   return metadataGets.set(genesisHash, def);
+}
+
+export function getSavedRawMeta (genesisHash: string): Promise<RawMetadataDef | null> | undefined {
+  return rawMetadataGets.get(genesisHash);
+}
+
+export function setSavedRawMeta (genesisHash: string, def: Promise<RawMetadataDef | null>): Map<string, Promise<RawMetadataDef | null>> {
+  return rawMetadataGets.set(genesisHash, def);
 }

--- a/packages/extension-ui/src/Popup/Signing/LedgerSign.tsx
+++ b/packages/extension-ui/src/Popup/Signing/LedgerSign.tsx
@@ -26,7 +26,9 @@ interface Props {
 function LedgerSign ({ accountIndex, addressOffset, className, error, genesisHash, onSignature, payload, setError }: Props): React.ReactElement<Props> {
   const [isBusy, setIsBusy] = useState(false);
   const { t } = useTranslation();
-  const { error: ledgerError, isLoading: ledgerLoading, isLocked: ledgerLocked, ledger, refresh, warning: ledgerWarning } = useLedger(genesisHash, accountIndex, addressOffset);
+  const { error: ledgerError, isLoading: ledgerLoading, isLocked: ledgerLocked, ledger, rawMetadata, refresh, warning: ledgerWarning } = useLedger(genesisHash, accountIndex, addressOffset);
+  const rawMeta = rawMetadata ? rawMetadata.rawMetadata : '0x';
+  const metaBuff = Buffer.from(rawMeta);
 
   useEffect(() => {
     if (ledgerError) {
@@ -47,7 +49,7 @@ function LedgerSign ({ accountIndex, addressOffset, className, error, genesisHas
 
       setError(null);
       setIsBusy(true);
-      ledger.sign(payload.toU8a(true), accountIndex, addressOffset)
+      ledger.signWithMetadata(payload.toU8a(true), accountIndex, addressOffset, { metadata: metaBuff})
         .then((signature) => {
           onSignature(signature);
         }).catch((e: Error) => {

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2019-2024 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountJson, AccountsContext, AuthorizeRequest, MetadataRequest, SigningRequest } from '@polkadot/extension-base/background/types';
+import type { AccountJson, AccountsContext, AuthorizeRequest, MetadataRequest, RawMetadataRequest, SigningRequest } from '@polkadot/extension-base/background/types';
 import type { SettingsStruct } from '@polkadot/ui-settings/types';
 
 import React, { useCallback, useEffect, useState } from 'react';
@@ -14,7 +14,7 @@ import { settings } from '@polkadot/ui-settings';
 import { AccountContext, ActionContext, AuthorizeReqContext, MediaContext, MetadataReqContext, SettingsContext, SigningReqContext } from '../components/contexts.js';
 import { ErrorBoundary, Loading } from '../components/index.js';
 import ToastProvider from '../components/Toast/ToastProvider.js';
-import { subscribeAccounts, subscribeAuthorizeRequests, subscribeMetadataRequests, subscribeSigningRequests } from '../messaging.js';
+import { subscribeAccounts, subscribeAuthorizeRequests, subscribeMetadataRequests, subscribeRawMetadataRequests, subscribeSigningRequests } from '../messaging.js';
 import { buildHierarchy } from '../util/buildHierarchy.js';
 import Accounts from './Accounts/index.js';
 import AccountManagement from './AuthManagement/AccountManagement.js';
@@ -74,6 +74,7 @@ export default function Popup (): React.ReactElement {
   const [cameraOn, setCameraOn] = useState(startSettings.camera === 'on');
   const [mediaAllowed, setMediaAllowed] = useState(false);
   const [metaRequests, setMetaRequests] = useState<null | MetadataRequest[]>(null);
+  const [rawMetaRequests, setRawMetaRequests] = useState<null | RawMetadataRequest[]>(null);
   const [signRequests, setSignRequests] = useState<null | SigningRequest[]>(null);
   const [isWelcomeDone, setWelcomeDone] = useState(false);
   const [settingsCtx, setSettingsCtx] = useState<SettingsStruct>(startSettings);
@@ -104,6 +105,7 @@ export default function Popup (): React.ReactElement {
       subscribeAccounts(setAccounts),
       subscribeAuthorizeRequests(setAuthRequests),
       subscribeMetadataRequests(setMetaRequests),
+      subscribeRawMetadataRequests(setRawMetaRequests),
       subscribeSigningRequests(setSignRequests)
     ]).catch(console.error);
 

--- a/packages/extension-ui/src/hooks/useLedger.ts
+++ b/packages/extension-ui/src/hooks/useLedger.ts
@@ -1,19 +1,16 @@
 // Copyright 2019-2024 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// This is to ensure the legacy `class Ledger` doesn't throw linting errors.
-//
-/* eslint-disable deprecation/deprecation */
-
 import type { Network } from '@polkadot/networks/types';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Ledger } from '@polkadot/hw-ledger';
+import { LedgerGeneric } from '@polkadot/hw-ledger';
 import { settings } from '@polkadot/ui-settings';
 import { assert } from '@polkadot/util';
 
 import ledgerChains from '../util/legerChains.js';
+import useMetadata from './useMetadata.js';
 import useTranslation from './useTranslation.js';
 
 interface StateBase {
@@ -26,7 +23,7 @@ interface State extends StateBase {
   error: string | null;
   isLoading: boolean;
   isLocked: boolean;
-  ledger: Ledger | null;
+  ledger: LedgerGeneric | null;
   refresh: () => void;
   warning: string | null;
 }
@@ -44,8 +41,8 @@ function getState (): StateBase {
   };
 }
 
-function retrieveLedger (genesis: string): Ledger {
-  let ledger: Ledger | null = null;
+function retrieveLedger (genesis: string): LedgerGeneric {
+  let ledger: LedgerGeneric | null = null;
 
   const { isLedgerCapable } = getState();
 
@@ -55,7 +52,9 @@ function retrieveLedger (genesis: string): Ledger {
 
   assert(def, 'There is no known Ledger app available for this chain');
 
-  ledger = new Ledger('webusb', def.network);
+  assert(def.slip44, 'Slip44 is not available for this network, please report an issue to update this chains slip44');
+
+  ledger = new LedgerGeneric('webusb', def.network, def.slip44);
 
   return ledger;
 }
@@ -67,6 +66,7 @@ export default function useLedger (genesis?: string | null, accountIndex = 0, ad
   const [warning, setWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [address, setAddress] = useState<string | null>(null);
+  const chainInfo = useMetadata(genesis);
   const { t } = useTranslation();
   const ledger = useMemo(() => {
     setError(null);
@@ -102,7 +102,9 @@ export default function useLedger (genesis?: string | null, accountIndex = 0, ad
     setError(null);
     setWarning(null);
 
-    ledger.getAddress(false, accountIndex, addressOffset)
+    // TODO - consider ensuring ss58 address is no longer an optional input for the metadata information.
+    // Also this should be an opportunity to ensure we include any data needed.
+    ledger.getAddress(chainInfo?.ss58Format || 0, false, accountIndex, addressOffset)
       .then((res) => {
         setIsLoading(false);
         setAddress(res.address);

--- a/packages/extension-ui/src/hooks/useLedger.ts
+++ b/packages/extension-ui/src/hooks/useLedger.ts
@@ -12,6 +12,8 @@ import { assert } from '@polkadot/util';
 import ledgerChains from '../util/legerChains.js';
 import useMetadata from './useMetadata.js';
 import useTranslation from './useTranslation.js';
+import useRawMetadata from './useRawMetadata.js';
+import type { RawMetadataDef } from '@polkadot/extension-inject/types';
 
 interface StateBase {
   isLedgerCapable: boolean;
@@ -24,6 +26,7 @@ interface State extends StateBase {
   isLoading: boolean;
   isLocked: boolean;
   ledger: LedgerGeneric | null;
+  rawMetadata: RawMetadataDef | null;
   refresh: () => void;
   warning: string | null;
 }
@@ -67,6 +70,7 @@ export default function useLedger (genesis?: string | null, accountIndex = 0, ad
   const [error, setError] = useState<string | null>(null);
   const [address, setAddress] = useState<string | null>(null);
   const chainInfo = useMetadata(genesis);
+  const rawMetadata = useRawMetadata(genesis);
   const { t } = useTranslation();
   const ledger = useMemo(() => {
     setError(null);
@@ -140,5 +144,5 @@ export default function useLedger (genesis?: string | null, accountIndex = 0, ad
     setWarning(null);
   }, []);
 
-  return ({ ...getState(), address, error, isLoading, isLocked, ledger, refresh, warning });
+  return ({ ...getState(), address, error, isLoading, isLocked, ledger, rawMetadata, refresh, warning });
 }

--- a/packages/extension-ui/src/hooks/useRawMetadata.ts
+++ b/packages/extension-ui/src/hooks/useRawMetadata.ts
@@ -1,0 +1,27 @@
+// Copyright 2019-2024 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
+import { useEffect, useState } from 'react';
+
+import { getRawMetadata } from '../messaging.js';
+import type { RawMetadataDef } from '@polkadot/extension-inject/types';
+
+export default function useRawMetadata(genesisHash?: string | null): RawMetadataDef | null {
+    const [rawMetadata, setRawMetadata] = useState<RawMetadataDef | null>(null);
+
+    useEffect((): void => {
+        if (genesisHash) {
+            getRawMetadata(genesisHash)
+                .then(setRawMetadata)
+                .catch((error): void => {
+                    console.error(error);
+                    setRawMetadata(null);
+                });
+        } else {
+            setRawMetadata(null);
+        }
+    }, [genesisHash]);
+
+    return rawMetadata;
+}

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -4,10 +4,10 @@
 /* global chrome */
 /* eslint-disable no-redeclare */
 
-import type { AccountJson, AllowedPath, AuthorizeRequest, ConnectedTabsUrlResponse, MessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithNullRequest, MessageTypesWithSubscriptions, MetadataRequest, RequestTypes, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSigningIsLocked, ResponseTypes, SeedLengths, SigningRequest, SubscriptionMessageTypes } from '@polkadot/extension-base/background/types';
+import type { AccountJson, AllowedPath, AuthorizeRequest, ConnectedTabsUrlResponse, MessageTypes, MessageTypesWithNoSubscriptions, MessageTypesWithNullRequest, MessageTypesWithSubscriptions, MetadataRequest, RawMetadataRequest, RequestTypes, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSigningIsLocked, ResponseTypes, SeedLengths, SigningRequest, SubscriptionMessageTypes } from '@polkadot/extension-base/background/types';
 import type { Message } from '@polkadot/extension-base/types';
 import type { Chain } from '@polkadot/extension-chains/types';
-import type { MetadataDef } from '@polkadot/extension-inject/types';
+import type { MetadataDef, RawMetadataDef } from '@polkadot/extension-inject/types';
 import type { KeyringPair$Json } from '@polkadot/keyring/types';
 import type { KeyringPairs$Json } from '@polkadot/ui-keyring/types';
 import type { HexString } from '@polkadot/util/types';
@@ -18,7 +18,7 @@ import { getId } from '@polkadot/extension-base/utils/getId';
 import { metadataExpand } from '@polkadot/extension-chains';
 
 import allChains from './util/chains.js';
-import { getSavedMeta, setSavedMeta } from './MetadataCache.js';
+import { getSavedMeta, getSavedRawMeta, setSavedMeta, setSavedRawMeta } from './MetadataCache.js';
 
 interface Handler {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,6 +106,10 @@ export async function approveMetaRequest (id: string): Promise<boolean> {
   return sendMessage('pri(metadata.approve)', { id });
 }
 
+export async function approveRawMetaRequest (id: string): Promise<boolean> {
+  return sendMessage('pri(metadata.approveRaw)', { id });
+}
+
 export async function cancelSignRequest (id: string): Promise<boolean> {
   return sendMessage('pri(signing.cancel)', { id });
 }
@@ -175,6 +179,23 @@ export async function getMetadata (genesisHash?: string | null, isPartial = fals
   return null;
 }
 
+export async function getRawMetadata (genesisHash: string): Promise<RawMetadataDef | null> {
+  if (!genesisHash) {
+    return null;
+  }
+  
+  let request = getSavedRawMeta(genesisHash);
+
+  if (!request) {
+    request = sendMessage('pri(metadata.getRaw)', genesisHash || null);
+    setSavedRawMeta(genesisHash, request);
+  }
+
+  const def = await request;
+
+  return def
+}
+
 export async function getConnectedTabsUrl (): Promise<ConnectedTabsUrlResponse> {
   return sendMessage('pri(connectedTabsUrl.get)', null);
 }
@@ -209,6 +230,10 @@ export async function deleteAuthRequest (requestId: string): Promise<void> {
 
 export async function subscribeMetadataRequests (cb: (accounts: MetadataRequest[]) => void): Promise<boolean> {
   return sendMessage('pri(metadata.requests)', null, cb);
+}
+
+export async function subscribeRawMetadataRequests (cb: (accounts: RawMetadataRequest[]) => void): Promise<boolean> {
+  return sendMessage('pri(metadata.requestsRaw)', null, cb);
 }
 
 export async function subscribeSigningRequests (cb: (accounts: SigningRequest[]) => void): Promise<boolean> {

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -7,7 +7,7 @@
   "manifest_version": 3,
   "permissions": ["storage", "tabs", "alarms"],
   "background": {
-    "scripts": ["background.js"],
+    "service_worker": "background.js",
     "type": "module"
   },
   "action": {


### PR DESCRIPTION
WIP

This PR is going to require adding a new `getRawMetadata` interface to the extension in order to work with the new ledger metadataHash proof signing.

My goal is to release the extension first to ensure we can get ledger support in apps. Then work on this immediately after.