### PR TITLE
fix(bug): updated `manifest,json` for Firefox

### DIFF
--- a/packages/extension/manifest_firefox.json
+++ b/packages/extension/manifest_firefox.json
@@ -17,7 +17,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "polkadotjavascript@gmail.com",
-      "strict_min_version": "42.0"
+      "strict_min_version": "108.0.2"
     }
   },
   "content_scripts": [{

--- a/packages/extension/manifest_firefox.json
+++ b/packages/extension/manifest_firefox.json
@@ -14,6 +14,12 @@
     "default_title": "polkadot{.js}",
     "default_popup": "index.html"
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "polkadotjavascript@gmail.com",
+      "strict_min_version": "42.0"
+    }
+  },
   "content_scripts": [{
     "js": ["content.js"],
     "matches": ["http://*/*", "https://*/*"],


### PR DESCRIPTION
Updated `manifest_firefox.json` to include:
```
  "browser_specific_settings": {
    "gecko": {
      "id": "polkadotjavascript@gmail.com",
      "strict_min_version": "108.0.2"
    }
  },
  ```

rel: #1395 

  NOTE: `strict_min_version` set to `108.0.2` for no other reason than it being released on Jan 5 2023, and >1 year of support seems reasonable enough.