### PR TITLE
Set firefox manifest id to correct embedded ID

### DIFF
--- a/packages/extension/manifest_firefox.json
+++ b/packages/extension/manifest_firefox.json
@@ -16,7 +16,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "polkadotjavascript@gmail.com",
+      "id": "7e3ce1f0-15fb-4fb1-99c6-25774749ec6d",
       "strict_min_version": "108.0.2"
     }
   },


### PR DESCRIPTION
The ID in the manifest field is wrong since we didn't use the email in the past. In this case its the embedded id set by Firefox in the past. 