### PR TITLE
Fix ID for firefox with brackets

### DIFF
--- a/packages/extension/manifest_firefox.json
+++ b/packages/extension/manifest_firefox.json
@@ -16,7 +16,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "7e3ce1f0-15fb-4fb1-99c6-25774749ec6d",
+      "id": "{7e3ce1f0-15fb-4fb1-99c6-25774749ec6d}",
       "strict_min_version": "108.0.2"
     }
   },


### PR DESCRIPTION
For manifest v3 the id required brackets....