### PR TITLE
chore: add heartbeat

### DIFF
--- a/packages/extension/src/heartbeat.ts
+++ b/packages/extension/src/heartbeat.ts
@@ -1,0 +1,39 @@
+// Copyright 2019-2024 @polkadot/extension authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Heartbeat functions as described by google.
+ *
+ * @see https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep_a_service_worker_alive_continuously
+ */
+
+let heartbeatInterval: string | number | NodeJS.Timeout | undefined;
+
+export async function runHeartbeat () {
+  await chrome.storage.local.set({ 'last-heartbeat': new Date().getTime() });
+}
+
+/**
+ * Starts the heartbeat interval which keeps the service worker alive. Call
+ * this sparingly when you are doing work which requires persistence, and call
+ * stopHeartbeat once that work is complete.
+ */
+export async function startHeartbeat () {
+  // Run the heartbeat once at service worker startup.
+  runHeartbeat().then(() => {
+    // Then again every 20 seconds.
+    heartbeatInterval = setInterval(runHeartbeat, 20 * 1000);
+  });
+}
+
+export async function stopHeartbeat () {
+  clearInterval(heartbeatInterval);
+}
+
+/**
+ * Returns the last heartbeat stored in extension storage, or undefined if
+ * the heartbeat has never run before.
+ */
+export async function getLastHeartbeat () {
+  return (await chrome.storage.local.get('last-heartbeat'))['last-heartbeat'];
+}


### PR DESCRIPTION
Add heartbeat as a loop and as an alarm to prevent service worker from being killed (90% of the time).