### PR TITLE
fix(bug): extension stuck in `... loading ...` screen after `service_worker` got terminated

### DIFF
--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -30,33 +30,34 @@ interface Handler {
 
 type Handlers = Record<string, Handler>;
 
-
-async function wakeupBackground(): Promise<Error | null> {
+async function wakeupBackground (): Promise<Error | null> {
   try {
-    await chrome.runtime.sendMessage({ type: "wakeup" })
-    return null
+    await chrome.runtime.sendMessage({ type: 'wakeup' });
+
+    return null;
   } catch (cause) {
-    return cause instanceof Error ? cause : new Error(String(cause))
+    return cause instanceof Error ? cause : new Error(String(cause));
   }
 }
 
 async function createPort (name: string, maxAttempts: number, delayMs: number): Promise<chrome.runtime.Port> {
-  let lastError: Error | null = null
+  let lastError: Error | null = null;
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const error = await wakeupBackground()
+    const error = await wakeupBackground();
+
     if (error) {
-      lastError = error
-      await new Promise((resolve) => setTimeout(resolve, delayMs))
-      continue
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      continue;
     }
 
-    const port = chrome.runtime.connect({ name })
+    const port = chrome.runtime.connect({ name });
 
-    return port
+    return port;
   }
 
-  throw new Error("Failed to create port after multiple attempts", { cause: lastError })
+  throw new Error('Failed to create port after multiple attempts', { cause: lastError });
 }
 
 const port = await createPort(PORT_EXTENSION, 5, 1000);

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -30,7 +30,36 @@ interface Handler {
 
 type Handlers = Record<string, Handler>;
 
-const port = chrome.runtime.connect({ name: PORT_EXTENSION });
+
+async function wakeupBackground(): Promise<Error | null> {
+  try {
+    await chrome.runtime.sendMessage({ type: "wakeup" })
+    return null
+  } catch (cause) {
+    return cause instanceof Error ? cause : new Error(String(cause))
+  }
+}
+
+async function createPort (name: string, maxAttempts: number, delayMs: number): Promise<chrome.runtime.Port> {
+  let lastError: Error | null = null
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const error = await wakeupBackground()
+    if (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      continue
+    }
+
+    const port = chrome.runtime.connect({ name })
+
+    return port
+  }
+
+  throw new Error("Failed to create port after multiple attempts", { cause: lastError })
+}
+
+const port = await createPort(PORT_EXTENSION, 5, 1000);
 const handlers: Handlers = {};
 
 // setup a listener for messages, any incoming resolves the promise

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -50,6 +50,12 @@ function getActiveTabs () {
   });
 }
 
+chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
+  if (message.type === "wakeup") {
+    sendResponse({ status: "awake" })
+  }
+})
+
 // listen to tab updates this is fired on url change
 chrome.tabs.onUpdated.addListener((_, changeInfo) => {
   // we are only interested in url change

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -50,11 +50,11 @@ function getActiveTabs () {
   });
 }
 
-chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
-  if (message.type === "wakeup") {
-    sendResponse({ status: "awake" })
+chrome.runtime.onMessage.addListener((message: { type: string }, _, sendResponse) => {
+  if (message.type === 'wakeup') {
+    sendResponse({ status: 'awake' });
   }
-})
+});
 
 // listen to tab updates this is fired on url change
 chrome.tabs.onUpdated.addListener((_, changeInfo) => {


### PR DESCRIPTION
This sends a message to wake up the `service_worker` when it has been terminated by the spec of the `manifest_V3`. Up to now, after 30 seconds have passed idle, the `service_worker` got terminated, and trying to access the popup would show `... loading ...`, and the user would have to close it and reopen it in order to correctly get the extension to render. 