### PR TITLE
Fix SignArea and ToastProvider timeout

### DIFF
--- a/packages/extension-ui/src/components/Toast/ToastProvider.tsx
+++ b/packages/extension-ui/src/components/Toast/ToastProvider.tsx
@@ -1,9 +1,7 @@
 // Copyright 2019-2024 @polkadot/extension-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/* global chrome */
-
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { ToastContext } from '../index.js';
 import Toast from './Toast.js';
@@ -13,37 +11,18 @@ interface ToastProviderProps {
 }
 
 const TOAST_TIMEOUT = 1500;
-const ALARM_NAME = 'toastAlarm';
 
 const ToastProvider = ({ children }: ToastProviderProps): React.ReactElement<ToastProviderProps> => {
   const [content, setContent] = useState('');
   const [visible, setVisible] = useState(false);
 
-  useEffect(() => {
-    const createAlarm = async () => {
-      try {
-        await chrome.alarms.create(ALARM_NAME, { delayInMinutes: TOAST_TIMEOUT / 60000 });
-        chrome.alarms.onAlarm.addListener((alarm) => {
-          if (alarm.name === ALARM_NAME) {
-            setVisible(false);
-          }
-        });
-      } catch (error) {
-        console.error('Error creating the alarm:', error);
-        throw error;
-      }
-    };
+  const show = useCallback((message: string): () => void => {
+    const timerId = setTimeout(() => setVisible(false), TOAST_TIMEOUT);
 
-    createAlarm().then(async () => {
-      return await chrome.alarms.clear(ALARM_NAME);
-    }).catch((error) => console.error('Error clearing the alarm: ', error));
-  }, []);
-
-  const show = useCallback((message: string): (() => void) => {
     setContent(message);
     setVisible(true);
 
-    return (): void => setVisible(false);
+    return (): void => clearTimeout(timerId);
   }, []);
 
   return (


### PR DESCRIPTION
in PR #1367 `setTimeout` was replaced with `chrome.alarms` in both the `SignArea` and `ToastProvider` components. Manifest V3 only recommends against the use of `setTimeout` in service workers / background scripts as the scripts don't run continuously. For front end UI components where the timeout is only required while the UI component is active `setTimeout` is still fine to use.

Currently with the `ToastProvider` it is trying to create an alarm of 1.5 seconds. The minimum `chrome.alarms` duration is 30 seconds so this is throwing a console error
> Alarm delay is less than the minimum duration of 30 seconds. In packed extensions, alarm "toastAlarm" will fire after the minimum duration.

Also the code is creating and then removing it straight away and is in a useEffect that only runs once when the provider is initialized. As a result when `show` is called the toast message never clears. This can be seen by clicking the copy button to copy a mnemonic when creating a new account. The timeout/alarm would need to be part of the `show` callback like it was originally. I reverted the changes to `ToastProvider` which resolves these issues.

Similarly there are issues in `SignArea` It is creating and removing the alarm immediately and does not have a listener for the alarm so it does nothing. I've fixed this component to correctly use the alarm but it possibly could also have been reverted to using `setTimeout`. For front end component the only benefit of using an alarm would be if the alarm needed to persist after the component unmounted or if the alarm state needed to be shared across components. (I'd fixed this before I realized `setTimeout` would have been fine to use which is why i didn't just revert this file also but still can if you think it might be a better option)