### PR TITLE
Fix setting rawMetadata as registry metadata

### DIFF
--- a/packages/extension-chains/src/bundle.ts
+++ b/packages/extension-chains/src/bundle.ts
@@ -26,7 +26,7 @@ export function metadataExpand (definition: MetadataDef, isPartial = false): Cha
     return cached;
   }
 
-  const { chain, genesisHash, icon, metaCalls, rawMetadata, specVersion, ss58Format, tokenDecimals, tokenSymbol, types, userExtensions } = definition;
+  const { chain, genesisHash, icon, metaCalls, specVersion, ss58Format, tokenDecimals, tokenSymbol, types, userExtensions } = definition;
   const registry = new TypeRegistry();
 
   if (!isPartial) {
@@ -41,8 +41,8 @@ export function metadataExpand (definition: MetadataDef, isPartial = false): Cha
 
   const hasMetadata = !!metaCalls && !isPartial;
 
-  if (hasMetadata || !!rawMetadata) {
-    registry.setMetadata(new Metadata(registry, hasMetadata ? base64Decode(metaCalls) : rawMetadata), undefined, userExtensions);
+  if (hasMetadata) {
+    registry.setMetadata(new Metadata(registry, base64Decode(metaCalls)), undefined, userExtensions);
   }
 
   const isUnknown = genesisHash === '0x';


### PR DESCRIPTION
This fixes a bug where the rawMetadata would reset the registry properties, and set the addresses to `ss58: 42` when metadata was updated. This fixes the following so that it no longer happens.