### PR TITLE
Reject instead of ignore

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -524,9 +524,15 @@ export default class Extension {
     return { list: remAuth };
   }
 
-  private deleteAuthRequest (requestId: string): void {
-    return this.#state.deleteAuthRequest(requestId);
-  }
+  private rejectAuthRequest (id: string): void {
+      const queued = this.#state.getAuthRequest(id);
+  
+      assert(queued, 'Unable to find request');
+  
+      const { reject } = queued;
+  
+      reject(new Error('Rejected'));
+    }
 
   private updateCurrentTabs ({ urls }: RequestActiveTabsUrlUpdate) {
     this.#state.updateCurrentTabsUrl(urls);
@@ -549,8 +555,8 @@ export default class Extension {
       case 'pri(authorize.remove)':
         return this.removeAuthorization(request as string);
 
-      case 'pri(authorize.delete.request)':
-        return this.deleteAuthRequest(request as string);
+      case 'pri(authorize.reject)':
+        return this.rejectAuthRequest(request as string);
 
       case 'pri(authorize.requests)':
         return port && this.authorizeSubscribe(id, port);

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -96,7 +96,7 @@ export interface RequestSignatures {
   'pri(authorize.list)': [null, ResponseAuthorizeList];
   'pri(authorize.requests)': [RequestAuthorizeSubscribe, boolean, AuthorizeRequest[]];
   'pri(authorize.remove)': [string, ResponseAuthorizeList];
-  'pri(authorize.delete.request)': [string, void];
+  'pri(authorize.reject)': [string, void];
   'pri(authorize.update)': [RequestUpdateAuthorizedAccounts, void];
   'pri(activeTabsUrl.update)': [RequestActiveTabsUrlUpdate, void];
   'pri(connectedTabsUrl.get)': [null, ConnectedTabsUrlResponse];

--- a/packages/extension-ui/src/Popup/Authorize/NoAccount.tsx
+++ b/packages/extension-ui/src/Popup/Authorize/NoAccount.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from 'react';
 import { Trans } from 'react-i18next';
 
 import { Button, Warning } from '../../components/index.js';
-import { deleteAuthRequest } from '../../messaging.js';
+import { rejectAuthRequest } from '../../messaging.js';
 import { styled } from '../../styled.js';
 
 interface Props {
@@ -16,7 +16,7 @@ interface Props {
 
 function NoAccount ({ authId, className }: Props): React.ReactElement<Props> {
   const _onClick = useCallback(() => {
-    deleteAuthRequest(authId).catch(console.error);
+    rejectAuthRequest(authId).catch(console.error);
   }, [authId]
   );
 

--- a/packages/extension-ui/src/Popup/Authorize/Request.tsx
+++ b/packages/extension-ui/src/Popup/Authorize/Request.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useContext, useEffect } from 'react';
 
 import { AccountContext, ActionBar, ActionContext, Button, Link } from '../../components/index.js';
 import { useTranslation } from '../../hooks/index.js';
-import { approveAuthRequest, deleteAuthRequest } from '../../messaging.js';
+import { approveAuthRequest, rejectAuthRequest } from '../../messaging.js';
 import { AccountSelection } from '../../partials/index.js';
 import { styled } from '../../styled.js';
 import NoAccount from './NoAccount.js';
@@ -44,7 +44,7 @@ function Request ({ authId, className, isFirst, request: { origin }, url }: Prop
 
   const _onClose = useCallback(
     (): void => {
-      deleteAuthRequest(authId)
+      rejectAuthRequest(authId)
         .then(() => onAction())
         .catch((error: Error) => console.error(error));
     },
@@ -77,7 +77,7 @@ function Request ({ authId, className, isFirst, request: { origin }, url }: Prop
           isDanger
           onClick={_onClose}
         >
-          {t('Ask again later')}
+          {t('Reject')}
         </Link>
       </ActionBar>
     </div>

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -220,8 +220,8 @@ export async function updateAuthorization (authorizedAccounts: string[], url: st
   return sendMessage('pri(authorize.update)', { authorizedAccounts, url });
 }
 
-export async function deleteAuthRequest (requestId: string): Promise<void> {
-  return sendMessage('pri(authorize.delete.request)', requestId);
+export async function rejectAuthRequest (requestId: string): Promise<void> {
+  return sendMessage('pri(authorize.reject)', requestId);
 }
 
 export async function subscribeMetadataRequests (cb: (accounts: MetadataRequest[]) => void): Promise<boolean> {


### PR DESCRIPTION
closes #1391 

This is not prefect, but it's a step in the right direction I believe.
When a user closes the authentication popup, nothing changes, the request is still here, it is still available in the extension on click. The icon also still shows that there's a pending "Auth" request.

Users however can now reject an authentication request. The Dapps will receive a "Reject" and no account will be shared. On the extension side, the connection will be made with 0 accounts and the Dapp that has called `web3Enable` will resolve with 0 accounts.