### PR TITLE
Add support for canceling authorization requests without authorizing sites

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -524,6 +524,8 @@ export default class Extension {
     return { list: remAuth };
   }
 
+  // Reject the authorization request and add the URL to the authorized list with no keys.
+  // The site will not prompt for re-authorization on future visits.
   private rejectAuthRequest (id: string): void {
     const queued = this.#state.getAuthRequest(id);
 
@@ -532,6 +534,18 @@ export default class Extension {
     const { reject } = queued;
 
     reject(new Error('Rejected'));
+  }
+
+  // Cancel the authorization request and do not add the URL to the authorized list.
+  // The site will prompt for authorization on future visits.
+  private cancelAuthRequest (id: string): void {
+    const queued = this.#state.getAuthRequest(id);
+
+    assert(queued, 'Unable to find request');
+
+    const { reject } = queued;
+
+    reject(new Error('Cancelled'));
   }
 
   private updateCurrentTabs ({ urls }: RequestActiveTabsUrlUpdate) {
@@ -557,6 +571,9 @@ export default class Extension {
 
       case 'pri(authorize.reject)':
         return this.rejectAuthRequest(request as string);
+
+      case 'pri(authorize.cancel)':
+        return this.cancelAuthRequest(request as string);
 
       case 'pri(authorize.requests)':
         return port && this.authorizeSubscribe(id, port);

--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -273,8 +273,14 @@ export default class State {
     return {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       reject: async (error: Error): Promise<void> => {
-        await complete();
-        reject(error);
+        if (error.message === 'Cancelled') {
+          delete this.#authRequests[id];
+          this.updateIconAuth(true);
+          reject(new Error('Connection request was cancelled by the user.'));
+        } else {
+          await complete();
+          reject(new Error('Connection request was rejected by the user.'));
+        }
       },
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       resolve: async ({ authorizedAccounts, result }: AuthResponse): Promise<void> => {

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -97,6 +97,7 @@ export interface RequestSignatures {
   'pri(authorize.requests)': [RequestAuthorizeSubscribe, boolean, AuthorizeRequest[]];
   'pri(authorize.remove)': [string, ResponseAuthorizeList];
   'pri(authorize.reject)': [string, void];
+  'pri(authorize.cancel)': [string, void];
   'pri(authorize.update)': [RequestUpdateAuthorizedAccounts, void];
   'pri(activeTabsUrl.update)': [RequestActiveTabsUrlUpdate, void];
   'pri(connectedTabsUrl.get)': [null, ConnectedTabsUrlResponse];

--- a/packages/extension-ui/src/Popup/AuthManagement/AccountManagement.tsx
+++ b/packages/extension-ui/src/Popup/AuthManagement/AccountManagement.tsx
@@ -42,41 +42,54 @@ function AccountManagement ({ className }: Props): React.ReactElement<Props> {
   );
 
   return (
-    <>
+    <div className={`${className}`}>
       <Header
         showBackArrow
         smallMargin={true}
         text={t('Accounts connected to {{url}}', { replace: { url } })}
       />
-      <div className={className}>
+      <div className='content'>
         <AccountSelection
-          className='accountSelection'
-          origin={origin}
+          origin={url}
           showHidden={true}
           url={url}
           withWarning={false}
         />
-        <Button
-          className='acceptButton'
-          onClick={_onApprove}
-        >
-          {t('Connect {{total}} account(s)', { replace: {
-            total: selectedAccounts.length
-          } })}
-        </Button>
+        <div className='footer'>
+          <Button
+            className='acceptButton'
+            onClick={_onApprove}
+          >
+            {t('Connect {{total}} account(s)', { replace: {
+              total: selectedAccounts.length
+            } })}
+          </Button>
+        </div>
       </div>
-    </>
+    </div>
   );
 }
 
 export default styled(AccountManagement)<Props>`
-  .accountSelection{
-    .accountList{
-      height: 390px;
-    }
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 550px;
+
+  .content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
   }
+
+  .footer {
+    background: var(--background);
+    flex-shrink: 0;
+  }
+
   .acceptButton {
     width: 90%;
-    margin: 0.5rem auto 0;
+    margin: 0.5rem auto;
   }
 `;

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -224,6 +224,10 @@ export async function rejectAuthRequest (requestId: string): Promise<void> {
   return sendMessage('pri(authorize.reject)', requestId);
 }
 
+export async function cancelAuthRequest (requestId: string): Promise<void> {
+  return sendMessage('pri(authorize.cancel)', requestId);
+}
+
 export async function subscribeMetadataRequests (cb: (accounts: MetadataRequest[]) => void): Promise<boolean> {
   return sendMessage('pri(metadata.requests)', null, cb);
 }

--- a/packages/extension-ui/src/partials/AccountSelection.tsx
+++ b/packages/extension-ui/src/partials/AccountSelection.tsx
@@ -17,7 +17,7 @@ interface Props {
   withWarning?: boolean;
 }
 
-function AccounSelection ({ className, origin, showHidden = false, url, withWarning = true }: Props): React.ReactElement<Props> {
+function AccountSelection ({ className, origin, showHidden = false, url, withWarning = true }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { accounts, hierarchy, selectedAccounts = [], setSelectedAccounts } = useContext(AccountContext);
   const [isIndeterminate, setIsIndeterminate] = useState(false);
@@ -90,10 +90,15 @@ function AccounSelection ({ className, origin, showHidden = false, url, withWarn
   );
 }
 
-export default styled(AccounSelection)<Props>`
+export default styled(AccountSelection)<Props>`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+
   .accountList {
     overflow-y: auto;
-    height: 270px;
+    min-height: 250px;
   }
 
   .tab-name,

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -179,5 +179,7 @@
   "This approval will add the metadata to your extension instance, allowing future requests to be decoded using this metadata. It will also allow the use of Ledger's Generic Polkadot App.": "",
   "No metadata found for this chain. You must upload the metadata to the extension in order to use Ledger.": "",
   "This network is not available, please report an issue to update the known chains": "",
-  "Ledger App": ""
+  "Ledger App": "",
+  "Don't ask again": "",
+  "Previous": ""
 }


### PR DESCRIPTION
PR #1453 added the ability to reject an authorization request, which is valuable as it throws an error that can be handled by the request originator. However, the current behavior still adds the site to the list of authorized sites, which may not always be desired.

This PR adds a new message handler `pri(authorize.cancel)` that:

- Deletes the authorization request (similar to previous `pri(authorize.delete.request)`)
- Rejects the authorization request with an error
= Does NOT add the URL to the list of authorized sites

The key difference is that users can now completely cancel an authorization attempt without having the site appear in their authorized sites list. The site will also prompt for authorization again for future attempts to connect the extension.