### PR TITLE
Ensure text is filtered so it doesnt cause white screens

### DIFF
--- a/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
+++ b/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
@@ -53,6 +53,7 @@ export default function useGenesisHashOptions (): Option[] {
           )
         )
       )
+      .filter((arr) => arr?.text)
       .sort((a, b) => a.text.localeCompare(b.text))
   ], [metadataChains, t]);
 


### PR DESCRIPTION
The following is a very small fix, but the problem causes white screens when text is undefined. 

rel: https://github.com/polkadot-js/extension/issues/1458