### PR TITLE
Sanitize dApp origin to prevent spoofing

### DIFF
--- a/packages/extension-ui/src/partials/AccountSelection.tsx
+++ b/packages/extension-ui/src/partials/AccountSelection.tsx
@@ -80,7 +80,7 @@ function AccountSelection ({ className, origin, showHidden = false, url, withWar
       )}
       {isSuspiciousOrigin && (
         <Warning className='warningError'>
-          It looks like this request is coming from an suspicious origin. Please verify the source carefully.
+          {t('It looks like this request is coming from an suspicious origin. Please verify the source carefully.')}
         </Warning>
       )}
       <Checkbox

--- a/packages/extension-ui/src/util/sanitizeOrigin.ts
+++ b/packages/extension-ui/src/util/sanitizeOrigin.ts
@@ -1,0 +1,58 @@
+// Copyright 2019-2025 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+const sanitizeHtml = (input: string, options?: {
+  allowLineBreaks?: boolean;
+  maxLength?: number;
+}): string => {
+  if (!input || typeof input !== 'string') {
+    return '';
+  }
+
+  let sanitized = input;
+
+  // Remove all HTML tags
+  sanitized = sanitized.replace(/<[^>]*>/g, '');
+
+  // Handle line breaks if specified
+  if (options?.allowLineBreaks) {
+    // Convert <br> to actual line breaks before sanitization
+    sanitized = input
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<[^>]*>/g, ''); // Remove other HTML tags
+  }
+
+  // Normalize whitespace
+  sanitized = sanitized
+    .trim()
+    .replace(/\s+/g, ' ');
+
+  // Apply length limit if specified
+  if (options?.maxLength && sanitized.length > options.maxLength) {
+    sanitized = sanitized.substring(0, options.maxLength) + '...';
+  }
+
+  return sanitized;
+};
+
+export const sanitizeOrigin = (origin: string): string => {
+  return sanitizeHtml(origin, {
+    allowLineBreaks: false,
+    maxLength: 50
+  });
+};
+
+// Validate that the origin looks legitimate
+export const validateOrigin = (origin: string): boolean => {
+  const sanitized = sanitizeOrigin(origin);
+
+  // Check for suspicious patterns
+  const suspiciousPatterns = [
+    /https?:\/\//i, // URLs in origin name
+    /[<>]/, // Remaining HTML characters
+    /^\s*$/, // Empty or whitespace only
+    /.{50,}/ // Extremely long names
+  ];
+
+  return !suspiciousPatterns.some((pattern) => pattern.test(sanitized));
+};

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -181,5 +181,6 @@
   "This network is not available, please report an issue to update the known chains": "",
   "Ledger App": "",
   "Don't ask again": "",
-  "Previous": ""
+  "Previous": "",
+  "It looks like this request is coming from an suspicious origin. Please verify the source carefully.": ""
 }


### PR DESCRIPTION
## 📝 Description

This pull request improves the sanitization of the dApp origin string displayed in the Polkadot extension's Enable access request dialog. Previously, certain HTML tags like `<br>` were not properly sanitized, allowing attackers to inject line breaks and other HTML, which could be exploited to spoof the origin and deceive users.

Unsanitized content in the origin display is a security risk as it can be exploited to visually mislead users into authorizing malicious dApps. This fix closes that attack vector by enforcing strict sanitization, thereby improving user safety and trust in the extension.

## 🤔 Previous behaviour

1. Access any webpage and open the browser's DevTools. (Make sure you have polkadot.js extension)
2. Execute the JavaScript code.

```ts
await injectedWeb3["polkadot-js"].enable(
  "polkadot-js/apps<br>is requesting access from<br>https://polkadot.js.org/<br><br><br><br><br><br><br><br><br><br><br><br><br><br><b>"
);
```

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/9b5d7afe-e161-417b-94df-d2f9b87f76c8" />

<hr />

## ✅ Current behaviour

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/71341333-051d-4921-87cf-93035a8deb9c" />