### PR TITLE
fix: Enforce distinct authorization for HTTP and HTTPS origins

### DIFF
--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -381,7 +381,8 @@ export default class State {
 
     const parts = url.split('/');
 
-    return parts[2];
+    // Keep protocol to distinguish http/https origins for security
+    return `${parts[0]}//${parts[2]}`;
   }
 
   private updateIcon (shouldClose?: boolean): void {

--- a/packages/extension-mocks/src/chrome.ts
+++ b/packages/extension-mocks/src/chrome.ts
@@ -33,7 +33,7 @@ chrome.storage.local.get.returns(
     try {
       const result = {
         authUrls: JSON.stringify({
-          'localhost:3000': {
+          'http://localhost:3000': {
             authorizedAccounts: ['5FbSap4BsWfjyRhCchoVdZHkDnmDm3NEgLZ25mesq4aw2WvX'],
             count: 0,
             id: '11',


### PR DESCRIPTION
## **Description**

This pull request resolves a security vulnerability where the extension failed to distinguish between a dApp's secure (`https`) and insecure (`http`) origins. By authorizing a site like `https://dapp.com`, a user would unknowingly also authorize `http://dapp.com`. This flaw could be exploited in a Manipulator-in-the-Middle (MitM) attack, where an attacker redirects a user to the insecure version of the site and injects malicious code to interact with the extension under the guise of the trusted origin.

The root cause was the `stripUrl()` function, which removed the protocol from the URL, leaving only the hostname as the identifier. The fix modifies this function to preserve the protocol (`https://` or `http://`) as part of the origin string. This change ensures that each origin is treated as unique and requires explicit user consent.

## **How to Reproduce the Vulnerability**

To test this, we will simulate the attack by running a simple dApp on two local servers: one on HTTP and one on HTTPS.

### 1. Setup the Test Environment:
*   Create an `index.html` in new directory.
```
<!DOCTYPE html>
<html>
<head>
  <title>Test DApp</title>
</head>
<body>
  <h1>Extension Tester</h1>
  <p>
    Current Status: <span id="status">Idle</span>
  </p>
  <button id="connectBtn">Connect to Extension</button>

  <script>
    async function connect() {
        const statusEl = document.getElementById('status');
        
        if (typeof window.injectedWeb3 === 'undefined') {
            statusEl.textContent = 'Polkadot{.js} extension not found.';
            return;
        }

        try {
            const dappName = 'Test DApp';
            const injection = await window.injectedWeb3['polkadot-js'].enable(dappName);
            const accounts = await injection.accounts.get();

            if (accounts.length === 0) {
                statusEl.textContent = 'No accounts found.';
                return;
            }

            statusEl.textContent = `Connected with ${accounts.length} accounts.`;
            console.log('Connected accounts:', accounts);
        } catch (e) {
            statusEl.textContent = `Error: ${e.message}`;
            console.error(e);
        }
    }

    document.getElementById('connectBtn').addEventListener('click', connect);
  </script>
</body>
</html> 
```
*   Generate a self-signed SSL certificate in the same directory:
    ```bash
    openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem
    ```
*   Install a simple server if you don't have one: `npm install -g http-server`.

## 2. Run Local Servers:
*   **HTTPS Server:** Open a terminal and run:
    ```bash
    http-server -S -p 8080
    ```
    1. Visit `https://localhost:8080`.  
    2. Bypass the browser's security warning for the self-signed certificate. 
    3. Click the connect button and **approve** the authorization request from the extension.
    4. Stop the server.

*   **HTTP Server:** Open a second terminal and run:
    ```bash
    http-server -p 8080
    ```
    1. Visit `http://localhost:8080` . 
    2. Click the connect button. The page will connect instantly without asking for authorization, demonstrating the vulnerability.


## Verify the Fix

Follow the exact same reproduction steps using a new extension built with these changes.

**Expected Result (with this fix):**

When you navigate to `http://localhost:8080` and click connect, the extension will now correctly identify it as a new, untrusted origin. It will pop up and ask for a **separate authorization**, confirming the vulnerability has been patched.