### PR TITLE
fix: signing extrinsics on ledger device

### DIFF
--- a/packages/extension-ui/src/Popup/Signing/Request/index.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request/index.tsx
@@ -11,7 +11,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { TypeRegistry } from '@polkadot/types';
 
 import { ActionContext, Address, VerticalSpace, Warning } from '../../../components/index.js';
-import { useTranslation } from '../../../hooks/index.js';
+import { useMetadata, useTranslation } from '../../../hooks/index.js';
 import { approveSignSignature } from '../../../messaging.js';
 import Bytes from '../Bytes.js';
 import Extrinsic from '../Extrinsic.js';
@@ -48,6 +48,15 @@ export default function Request ({ account: { accountIndex, addressOffset, genes
   const [{ hexBytes, payload }, setData] = useState<Data>({ hexBytes: null, payload: null });
   const [error, setError] = useState<string | null>(null);
   const { t } = useTranslation();
+  const chain = useMetadata(genesisHash);
+
+  useEffect((): void => {
+    // When the chain and request are ready, configure the chain's registry.
+    // This will be picked up by LedgerSign.
+    if (chain && !isRawPayload(request.payload)) {
+      chain.registry.setSignedExtensions(request.payload.signedExtensions, chain.definition.userExtensions);
+    }
+  }, [chain, request]);
 
   useEffect((): void => {
     const payload = request.payload;


### PR DESCRIPTION
**Fixes:** #1578

## Description

This PR addresses the following error encountered when signing an extrinsic using a Ledger device:

```
Uncaught TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
```

The error occurred during a call to [`getProofForExtrinsicPayload`](https://github.com/polkadot-js/extension/blob/master/packages/extension-ui/src/Popup/Signing/LedgerSign.tsx#L54), where the `ExtrinsicPayload` created [here](https://github.com/polkadot-js/extension/blob/master/packages/extension-ui/src/Popup/Signing/LedgerSign.tsx#L50) was missing required fields:

* `mode`
* `metadataHash`
* `transactionVersion`

These fields are necessary for generating the signing proof. The fix involves updating the `chain.registry.signedExtensions`, which ensures the missing fields are populated when constructing the `ExtrinsicPayload`.

